### PR TITLE
Add ouger as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ouger"]
+	path = ouger
+	url = https://github.com/rh-ecosystem-edge/ouger


### PR DESCRIPTION
This PR adds [ouger](https://github.com/rh-ecosystem-edge/ouger) as a git submodule and an additional Dockerfile stage for its building and copying into the recert release image.