### PR TITLE
Fix `Resource temporarily unavailable (os error 11)` errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cargo build --release --bin recert
 FROM docker.io/library/golang:1.19-bookworm as ouger-builder
 COPY ./ouger $GOPATH/src
 WORKDIR $GOPATH/src
-RUN go build -buildvcs=false -o $GOPATH/bin/ouger
+RUN CGO_ENABLED=0 go build -buildvcs=false -o $GOPATH/bin/ouger
 
 FROM docker.io/library/debian:bookworm AS runtime
 WORKDIR app


### PR DESCRIPTION
The resource in question seems to be PIDs. For some reason this seems to
not happen when CGO_ENABLED is set to 0, which IIUC means the pthread
library is not used by Go. I don't entirely understand this, but it
works.