### PR TITLE
Dry run mode

### DIFF
--- a/run_seed.sh
+++ b/run_seed.sh
@@ -12,7 +12,7 @@ if [[ ! -d backup ]]; then
     cat backup/blobs/sha256/$(cat backup/blobs/sha256/$(cat backup/index.json | jq '.manifests[0].digest' -r | cut -d ':' -f2) | jq '.layers[0].digest' -r | cut -d ':' -f2) | tar -xz -C backup
 fi
 
-rm -rf backup/etc backup/var backup/etc_orig backup/var_orig
+rm -rf backup/etc backup/var backup/etc_orig backup/var_orig backup/etcd_orig backup/etcd
 
 tar -C backup -xzf backup/etc.tgz
 tar -C backup -xzf backup/var.tgz
@@ -52,7 +52,9 @@ cargo run --release -- \
     --cn-san-replace *.apps.test-cluster.redhat.com:*.apps.new-name.foo.com \
     --cn-san-replace 192.168.127.10:192.168.127.11 \
     --summary-file summary.yaml \
-    --extend-expiration
+    --extend-expiration \
+    --dry-run
+    # --regenerate-server-ssh-keys backup/etc/ssh/ \
 
 cargo run --manifest-path etcddump/Cargo.toml --release -- --etcd-endpoint localhost:2379 --output-dir backup/etcd
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,12 +69,18 @@ pub(crate) struct Cli {
     pub(crate) threads: Option<usize>,
 
     /// Regenerate server SSH keys and write to this directory
-    #[clap(long, value_parser = clap::value_parser!(ClioPath).exists().is_dir())]
+    #[clap(long, group = "dry", value_parser = clap::value_parser!(ClioPath).exists().is_dir())]
     pub(crate) regenerate_server_ssh_keys: Option<ClioPath>,
 
     /// Generate a summary
     #[clap(long, value_parser = clap::value_parser!(ClioPath))]
     pub(crate) summary_file: Option<ClioPath>,
+
+    /// Don't actually commit anything to etcd/disk. Useful for validating that a cluster can be
+    /// recertified error-free before turning it into a seed image.
+    /// Note: the act of reading from etcd might sometimes cause changes to etcd
+    #[clap(long, group = "dry")]
+    pub(crate) dry_run: bool,
 }
 
 /// All the user requested customizations, coalesced into a single struct for convenience
@@ -87,6 +93,7 @@ pub(crate) struct Customizations {
 
 /// All parsed CLI arguments, coalesced into a single struct for convenience
 pub(crate) struct ParsedCLI {
+    pub(crate) dry_run: bool,
     pub(crate) etcd_endpoint: Option<String>,
     pub(crate) static_dirs: Vec<ClioPath>,
     pub(crate) static_files: Vec<ClioPath>,
@@ -101,6 +108,7 @@ pub(crate) fn parse_cli() -> Result<ParsedCLI> {
     let cli = Cli::parse();
 
     Ok(ParsedCLI {
+        dry_run: cli.dry_run,
         etcd_endpoint: cli.etcd_endpoint,
         static_dirs: cli.static_dir,
         static_files: cli.static_file,

--- a/src/cluster_crypto/cert_key_pair.rs
+++ b/src/cluster_crypto/cert_key_pair.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     cluster_crypto::{crypto_utils::key_from_file, locations::LocationValueType},
-    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, recreate_yaml_at_location_with_new_pem},
+    file_utils::{add_recert_edited_annotation, commit_file, get_filesystem_yaml, recreate_yaml_at_location_with_new_pem},
     k8s_etcd::{get_etcd_yaml, InMemoryK8sEtcd},
     rsa_key_pool::RsaKeyPool,
     Customizations,
@@ -355,7 +355,7 @@ impl CertKeyPair {
                 .encode_pem(),
         )?;
 
-        Ok(tokio::fs::write(
+        commit_file(
             &filelocation.path,
             match &filelocation.content_location {
                 FileContentLocation::Raw(location_value_type) => match &location_value_type {
@@ -383,7 +383,7 @@ impl CertKeyPair {
                 }
             },
         )
-        .await?)
+        .await
     }
 }
 

--- a/src/cluster_crypto/distributed_jwt.rs
+++ b/src/cluster_crypto/distributed_jwt.rs
@@ -6,7 +6,7 @@ use super::{
     locations::{FileContentLocation, FileLocation, K8sLocation, Location, LocationValueType, Locations},
 };
 use crate::{
-    file_utils::encode_resource_data_entry,
+    file_utils::{commit_file, encode_resource_data_entry},
     k8s_etcd::{get_etcd_yaml, InMemoryK8sEtcd},
 };
 use anyhow::{bail, Context, Result};
@@ -112,7 +112,7 @@ impl DistributedJwt {
     }
 
     pub(crate) async fn commit_to_filesystem(&self, filelocation: &FileLocation) -> Result<()> {
-        tokio::fs::write(
+        commit_file(
             &filelocation.path,
             match &filelocation.content_location {
                 FileContentLocation::Raw(pem_location_info) => match &pem_location_info {

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -7,7 +7,9 @@ use super::{
     signee::Signee,
 };
 use crate::{
-    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
+    file_utils::{
+        add_recert_edited_annotation, commit_file, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem,
+    },
     k8s_etcd::InMemoryK8sEtcd,
     rsa_key_pool::RsaKeyPool,
     Customizations,
@@ -102,7 +104,7 @@ impl DistributedPrivateKey {
             PrivateKey::Ec(ec_bytes) => pem::Pem::new("EC PRIVATE KEY", ec_bytes.as_ref()),
         };
 
-        tokio::fs::write(
+        commit_file(
             &filelocation.path,
             match &filelocation.content_location {
                 FileContentLocation::Raw(pem_location_info) => match &pem_location_info {

--- a/src/cluster_crypto/distributed_public_key.rs
+++ b/src/cluster_crypto/distributed_public_key.rs
@@ -7,7 +7,9 @@ use super::{
     pem_utils,
 };
 use crate::{
-    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
+    file_utils::{
+        add_recert_edited_annotation, commit_file, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem,
+    },
     k8s_etcd::{get_etcd_yaml, InMemoryK8sEtcd},
 };
 use std::fmt::Display;
@@ -91,7 +93,7 @@ impl DistributedPublicKey {
             PublicKey::Ec(_) => bail!("ECDSA public key not yet supported for filesystem commit"),
         };
 
-        tokio::fs::write(
+        commit_file(
             &filelocation.path,
             match &filelocation.content_location {
                 FileContentLocation::Raw(pem_location_info) => match &pem_location_info {

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -5,8 +5,22 @@ use crate::cluster_crypto::{
 use anyhow::{bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as base64_standard, Engine as _};
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::atomic::Ordering::Relaxed,
+};
 use tokio::io::AsyncReadExt;
+
+// Global dry run flag
+pub(crate) static DRY_RUN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub async fn commit_file(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
+    if !DRY_RUN.load(Relaxed) {
+        tokio::fs::write(path, contents).await?;
+    }
+
+    Ok(())
+}
 
 pub(crate) fn globvec(location: &Path, globstr: &str) -> Result<Vec<PathBuf>> {
     let mut globoptions = glob::MatchOptions::new();

--- a/src/k8s_etcd.rs
+++ b/src/k8s_etcd.rs
@@ -1,9 +1,8 @@
 use crate::cluster_crypto::locations::K8sResourceLocation;
-use crate::ouger::{ouger, OUGER_SERVER_PORT};
+use crate::ouger::ouger;
 use anyhow::{bail, Context, Result};
 use etcd_client::{Client as EtcdClient, GetOptions};
 use futures_util::future::join_all;
-use reqwest::Client;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -160,25 +159,6 @@ impl InMemoryK8sEtcd {
         self.deleted_keys.lock().await.insert(key.to_string());
         Ok(())
     }
-}
-
-pub(crate) async fn wait_for_ouger() {
-    let mut tries = 0;
-    while tries < 100 {
-        if Client::new()
-            .get(format!("http://localhost:{OUGER_SERVER_PORT}/healthz"))
-            .send()
-            .await
-            .is_ok()
-        {
-            return;
-        }
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        tries += 1;
-    }
-
-    panic!("Ouger server did not start in time");
 }
 
 pub(crate) async fn get_etcd_yaml(client: &InMemoryK8sEtcd, k8slocation: &K8sResourceLocation) -> Result<Option<Value>> {

--- a/src/ocp_postprocess/cluster_domain_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/filesystem_rename.rs
@@ -6,7 +6,7 @@ use super::{
     rename_utils::fix_oauth_metadata,
     rename_utils::{fix_kcm_pod, fix_machineconfig},
 };
-use crate::file_utils::{self, read_file_to_string};
+use crate::file_utils::{self, commit_file, read_file_to_string};
 use anyhow::{self, Context, Result};
 use futures_util::future::join_all;
 use serde_json::Value;
@@ -29,7 +29,7 @@ pub(crate) async fn fix_filesystem_kcm_pods(generated_infra_id: &str, dir: &Path
 
                         fix_kcm_pod(&mut pod, &generated_infra_id)?;
 
-                        tokio::fs::write(
+                        commit_file(
                             file_path,
                             serde_json::to_string(&pod).context("serializing kube-controller-manager-pod.yaml")?,
                         )
@@ -68,7 +68,7 @@ pub(crate) async fn fix_filesystem_kcm_configs(generated_infra_id: &str, dir: &P
 
                         fix_kcm_extended_args(&mut config, &generated_infra_id)?;
 
-                        tokio::fs::write(
+                        commit_file(
                             file_path,
                             serde_json::to_string(&config).context("serializing kube-controller-manager config.yaml")?,
                         )
@@ -107,7 +107,7 @@ pub(crate) async fn fix_filesystem_kube_apiserver_configs(cluster_domain: &str, 
 
                         fix_api_server_arguments(&mut config, &cluster_domain)?;
 
-                        tokio::fs::write(
+                        commit_file(
                             file_path,
                             serde_json::to_string(&config).context("serializing kube-apiserver config.yaml")?,
                         )
@@ -146,7 +146,7 @@ pub(crate) async fn fix_filesystem_kube_apiserver_oauth_metadata(cluster_domain:
 
                         fix_oauth_metadata(&mut config, &cluster_domain)?;
 
-                        tokio::fs::write(
+                        commit_file(
                             file_path,
                             serde_json::to_string(&config).context("serializing kube-apiserver oauthMetadata")?,
                         )
@@ -182,7 +182,7 @@ pub(crate) async fn fix_filesystem_currentconfig(cluster_domain: &str, dir: &Pat
 
                 fix_machineconfig(&mut config, &cluster_domain)?;
 
-                tokio::fs::write(file_path, serde_json::to_string(&config).context("serializing currentconfig")?)
+                commit_file(file_path, serde_json::to_string(&config).context("serializing currentconfig")?)
                     .await
                     .context("writing currentconfig to disk")?;
 
@@ -210,7 +210,7 @@ pub(crate) async fn fix_filesystem_apiserver_url_env_files(cluster_domain: &str,
                 let contents = read_file_to_string(file_path.clone()).await.context("reading apiserver-url.env")?;
 
                 // write back to disk
-                tokio::fs::write(file_path, fix_apiserver_url_file(contents.as_bytes().into(), &cluster_domain)?)
+                commit_file(file_path, fix_apiserver_url_file(contents.as_bytes().into(), &cluster_domain)?)
                     .await
                     .context("writing kubeconfig to disk")?;
 
@@ -251,7 +251,7 @@ pub(crate) async fn fix_filesystem_kubeconfigs(cluster_domain: &str, dir: &Path)
                             .await
                             .context("fixing kubeconfig")?;
 
-                        tokio::fs::write(file_path, serde_yaml::to_string(&yaml_value).context("serializing kubeconfig")?)
+                        commit_file(file_path, serde_yaml::to_string(&yaml_value).context("serializing kubeconfig")?)
                             .await
                             .context("writing kubeconfig to disk")?;
 


### PR DESCRIPTION
Don't actually commit anything to etcd/disk. Useful for validating that
a cluster can be recertified error-free before turning it into a seed
image.

Closes [MGMT-15982](https://issues.redhat.com//browse/MGMT-15982)