### PR TITLE
Use openssl for signing certs

### DIFF
--- a/src/cluster_crypto.rs
+++ b/src/cluster_crypto.rs
@@ -23,7 +23,6 @@ use std::{
 };
 use x509_certificate::X509CertificateError;
 
-mod cert_key_pair;
 mod crypto_objects;
 mod distributed_cert;
 mod distributed_jwt;
@@ -33,6 +32,7 @@ mod json_crawl;
 mod jwt;
 mod signee;
 
+pub(crate) mod cert_key_pair;
 pub(crate) mod certificate;
 pub(crate) mod crypto_utils;
 pub(crate) mod keys;

--- a/src/cluster_crypto/crypto_utils.rs
+++ b/src/cluster_crypto/crypto_utils.rs
@@ -12,6 +12,11 @@ use std::{path::PathBuf, process::Command as StdCommand};
 use tokio::process::Command;
 use x509_certificate::{rfc5280, EcdsaCurve, InMemorySigningKeyPair};
 
+pub(crate) struct SigningKey {
+    pub in_memory_signing_key_pair: InMemorySigningKeyPair,
+    pub pkcs8_pem: Vec<u8>,
+}
+
 /// Shell out to openssl to verify that a certificate is signed by a given signing certificate. We
 /// use this when our certificate lib doesn't support the signature algorithm used by the
 /// certificates.
@@ -57,35 +62,39 @@ pub(crate) fn verify_jwt(
     .verify_token::<Map<String, Value>>(&distributed_jwt.jwt.str, None)
 }
 
-pub(crate) async fn generate_rsa_key_async(key_size: usize) -> Result<InMemorySigningKeyPair> {
-    let private_key_parsed_pem = &pem::parse(
-        Command::new("openssl")
-            .args(["genrsa", &key_size.to_string()])
-            .output()
-            .await
-            .context("openssl genrsa")?
-            .stdout,
-    )
-    .context("private from pem")?;
+pub(crate) async fn generate_rsa_key_async(key_size: usize) -> Result<SigningKey> {
+    let pkcs8_pem = Command::new("openssl")
+        .args(["genrsa", &key_size.to_string()])
+        .output()
+        .await
+        .context("openssl genrsa")?
+        .stdout
+        .to_vec();
 
-    let key_pair = InMemorySigningKeyPair::from_pkcs8_der(private_key_parsed_pem.contents()).context("pair from der")?;
-    Ok(key_pair)
+    let in_memory_signing_key_pair = InMemorySigningKeyPair::from_pkcs8_pem(&pkcs8_pem).context("pair from der")?;
+
+    Ok(SigningKey {
+        in_memory_signing_key_pair,
+        pkcs8_pem,
+    })
 }
 
-pub(crate) fn generate_rsa_key(key_size: usize) -> Result<InMemorySigningKeyPair> {
-    let key_pair = InMemorySigningKeyPair::from_pkcs8_pem(
-        StdCommand::new("openssl")
-            .args(["genrsa", &key_size.to_string()])
-            .output()
-            .context("openssl genrsa")?
-            .stdout,
-    )
-    .context("pair from der")?;
+pub(crate) fn generate_rsa_key(key_size: usize) -> Result<SigningKey> {
+    let pkcs8_pem = StdCommand::new("openssl")
+        .args(["genrsa", &key_size.to_string()])
+        .output()
+        .context("openssl genrsa")?
+        .stdout;
 
-    Ok(key_pair)
+    let key_pair = InMemorySigningKeyPair::from_pkcs8_pem(&pkcs8_pem).context("pair from der")?;
+
+    Ok(SigningKey {
+        in_memory_signing_key_pair: key_pair,
+        pkcs8_pem,
+    })
 }
 
-pub(crate) fn generate_ec_key(ec_curve: EcdsaCurve) -> Result<InMemorySigningKeyPair> {
+pub(crate) fn generate_ec_key(ec_curve: EcdsaCurve) -> Result<SigningKey> {
     let gen_sec1_ec = StdCommand::new("openssl")
         .args([
             "ecparam",
@@ -103,32 +112,48 @@ pub(crate) fn generate_ec_key(ec_curve: EcdsaCurve) -> Result<InMemorySigningKey
         .spawn()
         .context("openssl ecdsa")?;
 
-    let pkcs8_der_data = StdCommand::new("openssl")
-        .args(["pkcs8", "-topk8", "-nocrypt", "-inform", "DER", "-outform", "DER"])
+    let pkcs8_pem_data = StdCommand::new("openssl")
+        .args(["pkcs8", "-topk8", "-nocrypt", "-inform", "DER"])
         .stdin(gen_sec1_ec.stdout.unwrap())
         .output()
         .context("openssl pkcs8")?
         .stdout;
 
-    let key_pair = InMemorySigningKeyPair::from_pkcs8_der(pkcs8_der_data).context("pair from der")?;
+    let key_pair = InMemorySigningKeyPair::from_pkcs8_pem(&pkcs8_pem_data).context("pair from der")?;
 
-    Ok(key_pair)
+    Ok(SigningKey {
+        in_memory_signing_key_pair: key_pair,
+        pkcs8_pem: pkcs8_pem_data,
+    })
 }
 
-pub(crate) fn key_from_pkcs8_file(path: &PathBuf) -> Result<InMemorySigningKeyPair> {
-    InMemorySigningKeyPair::from_pkcs8_pem(std::fs::read_to_string(path).context("reading private key file")?.as_str())
-        .context("pair from der")
+pub(crate) fn key_from_pkcs8_file(path: &PathBuf) -> Result<SigningKey> {
+    let pkcs8_pem_data = std::fs::read_to_string(path).context("reading private key file")?;
+    let in_memory_signing_key_pair = InMemorySigningKeyPair::from_pkcs8_pem(&pkcs8_pem_data).context("pair from der");
+
+    Ok(SigningKey {
+        in_memory_signing_key_pair: in_memory_signing_key_pair?,
+        pkcs8_pem: pkcs8_pem_data.into(),
+    })
 }
 
-pub(crate) fn rsa_key_from_pkcs1_file(path: &PathBuf) -> Result<InMemorySigningKeyPair> {
+pub(crate) fn rsa_key_from_pkcs1_file(path: &PathBuf) -> Result<SigningKey> {
     let rsa_private_key = RsaPrivateKey::from_pkcs1_pem(std::fs::read_to_string(path).context("reading private key file")?.as_str())
         .context("private from pem")?;
-    let rsa_pkcs8_der_bytes: Vec<u8> = rsa_private_key.to_pkcs8_der().context("private to der")?.as_bytes().into();
-    let key_pair = InMemorySigningKeyPair::from_pkcs8_der(rsa_pkcs8_der_bytes).context("pair from der")?;
-    Ok(key_pair)
+    let pkcs8_pem_data: Vec<u8> = rsa_private_key
+        .to_pkcs8_pem(pkcs1::LineEnding::LF)
+        .context("private to pkcs8 pem")?
+        .as_bytes()
+        .into();
+    let in_memory_signing_key_pair = InMemorySigningKeyPair::from_pkcs8_pem(&pkcs8_pem_data).context("pair from der")?;
+
+    Ok(SigningKey {
+        in_memory_signing_key_pair,
+        pkcs8_pem: pkcs8_pem_data,
+    })
 }
 
-pub(crate) fn key_from_file(path: &PathBuf) -> Result<InMemorySigningKeyPair> {
+pub(crate) fn key_from_file(path: &PathBuf) -> Result<SigningKey> {
     let parsed_pem = pem::parse(std::fs::read(path).context("reading private key file")?).context("parsing private key file")?;
     let pem_tag = parsed_pem.tag();
 
@@ -144,4 +169,31 @@ pub(crate) fn encode_tbs_cert_to_der(tbs_certificate: &rfc5280::TbsCertificate) 
     let mut tbs_der = Vec::<u8>::new();
     tbs_certificate.encode_ref().write_encoded(Mode::Der, &mut tbs_der)?;
     Ok(tbs_der)
+}
+
+pub(crate) fn sign(signing_key: &SigningKey, tbs_der: &[u8]) -> Result<Vec<u8>> {
+    let mut temp_file = tempfile::NamedTempFile::new()?;
+    temp_file.write_all(tbs_der)?;
+
+    let mut command = StdCommand::new("openssl")
+        .args([
+            "dgst",
+            "-sha256",
+            "-sign",
+            "/dev/stdin",
+            temp_file.path().to_str().context("getting temp file path")?,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("openssl dgst")?;
+
+    command
+        .stdin
+        .take()
+        .context("getting openssl dgst stdin")?
+        .write_all(signing_key.pkcs8_pem.as_slice())
+        .context("writing to openssl dgst stdin")?;
+
+    Ok(command.wait_with_output().context("waiting for openssl dgst")?.stdout)
 }

--- a/src/cluster_crypto/distributed_jwt.rs
+++ b/src/cluster_crypto/distributed_jwt.rs
@@ -1,5 +1,5 @@
 use super::{
-    crypto_utils::verify_jwt,
+    crypto_utils::{verify_jwt, SigningKey},
     jwt::Jwt,
     jwt::JwtSigner,
     keys::PublicKey,
@@ -27,7 +27,7 @@ pub(crate) struct DistributedJwt {
 }
 
 impl DistributedJwt {
-    pub(crate) fn regenerate(&mut self, original_signing_key: &PublicKey, new_signing_key: &InMemorySigningKeyPair) -> Result<()> {
+    pub(crate) fn regenerate(&mut self, original_signing_key: &PublicKey, new_signing_key: &SigningKey) -> Result<()> {
         let new_key = match &self.signer {
             JwtSigner::Unknown => bail!("cannot regenerate jwt with unknown signer"),
             JwtSigner::CertKeyPair(_cert_key_pair) => self.resign(original_signing_key, new_signing_key)?,
@@ -38,8 +38,8 @@ impl DistributedJwt {
         Ok(())
     }
 
-    fn resign(&self, original_public_key: &PublicKey, new_signing_key_pair: &InMemorySigningKeyPair) -> Result<String> {
-        match new_signing_key_pair {
+    fn resign(&self, original_public_key: &PublicKey, new_signing_key_pair: &SigningKey) -> Result<String> {
+        match &new_signing_key_pair.in_memory_signing_key_pair {
             InMemorySigningKeyPair::Ecdsa(_, _, _) => {
                 bail!("ecdsa unsupported");
             }

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -50,7 +50,7 @@ impl DistributedPrivateKey {
             )?;
         }
 
-        let regenerated_private_key: PrivateKey = (&self_new_key_pair).try_into()?;
+        let regenerated_private_key: PrivateKey = (&self_new_key_pair.in_memory_signing_key_pair).try_into()?;
         self.key_regenerated = Some(regenerated_private_key.clone());
 
         if let Some(public_key) = &self.associated_distributed_public_key {

--- a/src/cluster_crypto/signee.rs
+++ b/src/cluster_crypto/signee.rs
@@ -1,5 +1,6 @@
 use super::{
     cert_key_pair::{CertKeyPair, SerialNumberEdits, SkidEdits},
+    crypto_utils::SigningKey,
     distributed_jwt::DistributedJwt,
     keys,
 };
@@ -7,7 +8,6 @@ use crate::{rsa_key_pool::RsaKeyPool, Customizations};
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use std::{self, cell::RefCell, rc::Rc};
-use x509_certificate::InMemorySigningKeyPair;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Signee {
@@ -31,7 +31,7 @@ impl Signee {
     pub(crate) fn regenerate(
         &mut self,
         original_signing_public_key: &keys::PublicKey,
-        new_signing_key: Option<&InMemorySigningKeyPair>,
+        new_signing_key: Option<&SigningKey>,
         rsa_key_pool: &mut RsaKeyPool,
         customizations: &Customizations,
         skid_edits: Option<&mut SkidEdits>,

--- a/src/rsa_key_pool.rs
+++ b/src/rsa_key_pool.rs
@@ -1,15 +1,15 @@
 use super::cluster_crypto::crypto_utils::{generate_rsa_key, generate_rsa_key_async};
+use crate::cluster_crypto::crypto_utils::SigningKey;
 use anyhow::Result;
 use futures_util::future::join_all;
-use x509_certificate::InMemorySigningKeyPair;
 
 pub struct RsaKeyPool {
-    pub(crate) keys_2048: Vec<InMemorySigningKeyPair>,
-    pub(crate) keys_4096: Vec<InMemorySigningKeyPair>,
+    pub(crate) keys_2048: Vec<SigningKey>,
+    pub(crate) keys_4096: Vec<SigningKey>,
 }
 
 impl RsaKeyPool {
-    pub async fn fill(num_keys_2048: usize, num_keys_4096: usize) -> Result<Self> {
+    pub(crate) async fn fill(num_keys_2048: usize, num_keys_4096: usize) -> Result<Self> {
         Ok(Self {
             keys_2048: join_all(
                 (0..num_keys_2048)
@@ -35,7 +35,7 @@ impl RsaKeyPool {
         })
     }
 
-    pub fn get(&mut self, size: usize) -> Result<InMemorySigningKeyPair> {
+    pub(crate) fn get(&mut self, size: usize) -> Result<SigningKey> {
         let size = if size != 512 && size != 1024 && size != 2048 && size != 4096 {
             // HACK: If the size is not a power of 2, this is probably not RSA.
             // TODO: Remove this hack once we support non-RSA keys


### PR DESCRIPTION
This is important for FIPS compliance, we can't rely on random rust
crypto libraries for this.

Resolves [MGMT-15636](https://issues.redhat.com//browse/MGMT-15636)