### PR TITLE
Also rename machine-config-controller ControllerConfig

### DIFF
--- a/src/cluster_crypto.rs
+++ b/src/cluster_crypto.rs
@@ -148,7 +148,7 @@ impl ClusterCryptoObjects {
     /// cert-key pairs and standalone private keys, which will in turn regenerate all the objects
     /// that depend on them (signees). Requires that first the crypto objects have been paired and
     /// associated through the other methods.
-    fn regenerate_crypto(&mut self, mut rsa_key_pool: RsaKeyPool, customizations: Customizations) -> Result<()> {
+    fn regenerate_crypto(&mut self, mut rsa_key_pool: RsaKeyPool, customizations: &Customizations) -> Result<()> {
         let mut skid_edits = SkidEdits::new();
         let mut serial_number_edits = SerialNumberEdits::new();
 
@@ -157,17 +157,13 @@ impl ClusterCryptoObjects {
                 continue;
             }
 
-            (**cert_key_pair).borrow_mut().regenerate(
-                None,
-                &mut rsa_key_pool,
-                &customizations,
-                &mut skid_edits,
-                &mut serial_number_edits,
-            )?
+            (**cert_key_pair)
+                .borrow_mut()
+                .regenerate(None, &mut rsa_key_pool, customizations, &mut skid_edits, &mut serial_number_edits)?
         }
 
         for private_key in self.distributed_private_keys.values() {
-            (**private_key).borrow_mut().regenerate(&mut rsa_key_pool, &customizations)?
+            (**private_key).borrow_mut().regenerate(&mut rsa_key_pool, customizations)?
         }
 
         Ok(())
@@ -449,7 +445,7 @@ impl ClusterCryptoObjects {
     pub(crate) fn process_objects(
         &mut self,
         discovered_crypto_objects: Vec<DiscoveredCryptoObect>,
-        customizations: Customizations,
+        customizations: &Customizations,
         rsa_pool: RsaKeyPool,
     ) -> Result<()> {
         self.register_discovered_crypto_objects(discovered_crypto_objects);

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -17,7 +17,7 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use pkcs1::EncodeRsaPrivateKey;
 use serde::Serialize;
-use std::{self, cell::RefCell, rc::Rc};
+use std::{self, cell::RefCell, path::PathBuf, rc::Rc};
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DistributedPrivateKey {
@@ -120,7 +120,7 @@ impl DistributedPrivateKey {
             match &filelocation.content_location {
                 FileContentLocation::Raw(pem_location_info) => match &pem_location_info {
                     LocationValueType::Pem(pem_location_info) => pem_utils::pem_bundle_replace_pem_at_index(
-                        String::from_utf8((read_file_to_string(filelocation.path.clone().into()).await)?.into_bytes())?,
+                        String::from_utf8((read_file_to_string(&PathBuf::from(&filelocation.path)).await)?.into_bytes())?,
                         pem_location_info.pem_bundle_index,
                         &private_key_pem,
                     )?,

--- a/src/cluster_crypto/distributed_public_key.rs
+++ b/src/cluster_crypto/distributed_public_key.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     k8s_etcd::{get_etcd_json, InMemoryK8sEtcd},
 };
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct DistributedPublicKey {
@@ -114,7 +114,7 @@ impl DistributedPublicKey {
                 match &filelocation.content_location {
                     FileContentLocation::Raw(pem_location_info) => match &pem_location_info {
                         LocationValueType::Pem(pem_location_info) => pem_utils::pem_bundle_replace_pem_at_index(
-                            String::from_utf8((read_file_to_string(filelocation.path.clone().into()).await?).into_bytes())?,
+                            String::from_utf8((read_file_to_string(&PathBuf::from(filelocation.path.clone())).await?).into_bytes())?,
                             pem_location_info.pem_bundle_index,
                             &public_key_pem,
                         )?,

--- a/src/cluster_crypto/scanning.rs
+++ b/src/cluster_crypto/scanning.rs
@@ -312,7 +312,7 @@ pub(crate) async fn scan_filesystem_directory(dir: &Path) -> Result<Vec<Discover
 }
 
 async fn scan_filesystem_file(file_path: PathBuf) -> Result<Vec<DiscoveredCryptoObect>> {
-    let contents = read_file_to_string(file_path.to_path_buf()).await?;
+    let contents = read_file_to_string(&file_path).await?;
 
     anyhow::Ok(
         if String::from_utf8(file_path.file_name().context("non-file")?.as_bytes().to_vec())?

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -39,15 +39,15 @@ pub(crate) fn globvec(location: &Path, globstr: &str) -> Result<Vec<PathBuf>> {
     .collect::<Vec<_>>())
 }
 
-pub(crate) async fn read_file_to_string(file_path: PathBuf) -> Result<String> {
-    let mut file = tokio::fs::File::open(file_path.clone()).await?;
+pub(crate) async fn read_file_to_string(file_path: &Path) -> Result<String> {
+    let mut file = tokio::fs::File::open(file_path).await?;
     let mut contents = String::new();
     file.read_to_string(&mut contents).await.context("failed to read file")?;
     Ok(contents)
 }
 
 pub(crate) async fn get_filesystem_yaml(file_location: &FileLocation) -> Result<Value> {
-    serde_yaml::from_str(read_file_to_string(file_location.path.clone().into()).await?.as_str()).context("failed to parse yaml")
+    serde_yaml::from_str(read_file_to_string(&PathBuf::from(&file_location.path)).await?.as_str()).context("failed to parse yaml")
 }
 
 pub(crate) enum RecreateYamlEncoding {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ async fn run(parsed_cli: &ParsedCLI, cluster_crypto: &mut ClusterCryptoObjects) 
         cluster_crypto,
         &parsed_cli.cluster_rename,
         &parsed_cli.static_dirs,
+        &parsed_cli.static_files,
         parsed_cli.regenerate_server_ssh_keys.as_deref(),
         parsed_cli.dry_run,
     )
@@ -109,6 +110,7 @@ async fn finalize(
     cluster_crypto: &mut ClusterCryptoObjects,
     cluster_rename: &Option<ClusterRenameParameters>,
     static_dirs: &Vec<ClioPath>,
+    static_files: &Vec<ClioPath>,
     regenerate_server_ssh_keys: Option<&Path>,
     dry_run: bool,
 ) -> Result<()> {
@@ -118,7 +120,7 @@ async fn finalize(
         .context("commiting the cryptographic objects back to memory etcd and to disk")?;
 
     if in_memory_etcd_client.etcd_client.is_some() {
-        ocp_postprocess::ocp_postprocess(&in_memory_etcd_client, cluster_rename, static_dirs)
+        ocp_postprocess::ocp_postprocess(&in_memory_etcd_client, cluster_rename, static_dirs, static_files)
             .await
             .context("performing ocp specific post-processing")?;
     }

--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -18,6 +18,7 @@ pub(crate) async fn ocp_postprocess(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_rename_params: &Option<ClusterRenameParameters>,
     static_dirs: &Vec<ClioPath>,
+    static_files: &Vec<ClioPath>,
 ) -> Result<()> {
     fix_olm_secret_hash_annotation(in_memory_etcd_client)
         .await
@@ -30,7 +31,7 @@ pub(crate) async fn ocp_postprocess(
         .context("deleting node-kubeconfigs")?;
 
     if let Some(cluster_rename_params) = cluster_rename_params {
-        cluster_rename(in_memory_etcd_client, cluster_rename_params, static_dirs)
+        cluster_rename(in_memory_etcd_client, cluster_rename_params, static_dirs, static_files)
             .await
             .context("renaming cluster")?;
     }
@@ -127,14 +128,14 @@ pub(crate) async fn delete_pods(etcd_client: &Arc<InMemoryK8sEtcd>) -> Result<()
     Ok(())
 }
 
-/// kubeconfigs have a server URL that we should change to the new cluster's API server URL.
 pub(crate) async fn cluster_rename(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_rename: &ClusterRenameParameters,
     static_dirs: &Vec<ClioPath>,
+    static_files: &Vec<ClioPath>,
 ) -> Result<()> {
     let etcd_client = in_memory_etcd_client;
-    cluster_domain_rename::rename_all(etcd_client, cluster_rename, static_dirs)
+    cluster_domain_rename::rename_all(etcd_client, cluster_rename, static_dirs, static_files)
         .await
         .context("renaming all")?;
 

--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -16,8 +16,8 @@ pub(crate) mod cluster_domain_rename;
 /// Perform some OCP-related post-processing to make some OCP operators happy
 pub(crate) async fn ocp_postprocess(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
-    cluster_rename_params: Option<ClusterRenameParameters>,
-    static_dirs: Vec<ClioPath>,
+    cluster_rename_params: &Option<ClusterRenameParameters>,
+    static_dirs: &Vec<ClioPath>,
 ) -> Result<()> {
     fix_olm_secret_hash_annotation(in_memory_etcd_client)
         .await
@@ -130,8 +130,8 @@ pub(crate) async fn delete_pods(etcd_client: &Arc<InMemoryK8sEtcd>) -> Result<()
 /// kubeconfigs have a server URL that we should change to the new cluster's API server URL.
 pub(crate) async fn cluster_rename(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
-    cluster_rename: ClusterRenameParameters,
-    static_dirs: Vec<ClioPath>,
+    cluster_rename: &ClusterRenameParameters,
+    static_dirs: &Vec<ClioPath>,
 ) -> Result<()> {
     let etcd_client = in_memory_etcd_client;
     cluster_domain_rename::rename_all(etcd_client, cluster_rename, static_dirs)

--- a/src/ocp_postprocess/cluster_domain_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename.rs
@@ -200,6 +200,9 @@ async fn fix_etcd_resources(
     etcd_rename::fix_routes(etcd_client, cluster_domain)
         .await
         .context("fixing routes")?;
+    etcd_rename::fix_controller_config(etcd_client, &generated_infra_id, cluster_domain)
+        .await
+        .context("fixing routes")?;
     etcd_rename::delete_resources(etcd_client).await.context("fixing kcm pods")?;
     Ok(())
 }

--- a/src/ocp_postprocess/cluster_domain_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename.rs
@@ -11,13 +11,13 @@ mod rename_utils;
 
 pub(crate) async fn rename_all(
     etcd_client: &Arc<InMemoryK8sEtcd>,
-    cluster_rename: ClusterRenameParameters,
-    static_dirs: Vec<ClioPath>,
+    cluster_rename: &ClusterRenameParameters,
+    static_dirs: &Vec<ClioPath>,
 ) -> Result<(), anyhow::Error> {
     let cluster_domain = cluster_rename.cluster_domain();
     let generated_infra_id = rename_utils::generate_infra_id(cluster_rename.cluster_name.to_string())?;
 
-    fix_etcd_resources(etcd_client, &cluster_domain, generated_infra_id.clone(), &cluster_rename)
+    fix_etcd_resources(etcd_client, &cluster_domain, generated_infra_id.clone(), cluster_rename)
         .await
         .context("renaming etcd resources")?;
 
@@ -30,10 +30,10 @@ pub(crate) async fn rename_all(
 
 async fn fix_filesystem_resources(
     cluster_domain: &str,
-    static_dirs: Vec<ClioPath>,
+    static_dirs: &Vec<ClioPath>,
     generated_infra_id: String,
 ) -> Result<(), anyhow::Error> {
-    for dir in &static_dirs {
+    for dir in static_dirs {
         fix_dir_resources(cluster_domain, dir, &generated_infra_id).await?;
     }
 


### PR DESCRIPTION
This CR contains copies of the `cluster` Infrastructure CR and the
`cluster` DNS CR, both of which were previously renamed but these copied
embedded within the `machine-config-controller` ControllerConfig CR were
missed

Based on #48, see ff9d3ad for the actual changes