### PR TITLE
JWT signing FIPS compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,12 +223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binstring"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0d60973d9320722cb1206f412740e162a33b8547ea8d6be75d7cff237c7a85"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,18 +346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coarsetime"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73ef0d00d14301df35d0f13f5ea32344de6b00837485c358458f1e7f2d27db4"
-dependencies = [
- "libc",
- "once_cell",
- "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,27 +405,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-codecs"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
-
-[[package]]
 name = "data-url"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41b319d1b62ffbd002e057f36bebd1f42b9f97927c9577461d855f3513c4289f"
-
-[[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
 
 [[package]]
 name = "der"
@@ -454,7 +419,7 @@ dependencies = [
  "const-oid",
  "der_derive",
  "flagset",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -496,22 +461,12 @@ version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
- "der 0.7.8",
+ "der",
  "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.1.0",
- "spki 0.7.2",
-]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3d382e8464107391c8706b4c14b087808ecb909f6c15c34114bc42e53a9e4c"
-dependencies = [
- "ct-codecs",
- "getrandom",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -532,9 +487,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -783,43 +737,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "hmac-sha1-compact"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9d405ec732fa3fcde87264e54a32a84956a377b3e3107de96e59b798c84a7"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "hmac-sha512"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
 dependencies = [
  "digest",
 ]
@@ -995,46 +916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jwt-simple"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1283ac1b6399e76359084aede6e5edda7d8d3dac6725a9623c7c4f0e04bbd4df"
-dependencies = [
- "anyhow",
- "binstring",
- "coarsetime",
- "ct-codecs",
- "ed25519-compact",
- "hmac-sha1-compact",
- "hmac-sha256",
- "hmac-sha512",
- "k256",
- "p256",
- "p384",
- "rand",
- "rsa 0.7.2",
- "serde",
- "serde_json",
- "spki 0.6.0",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature 2.1.0",
 ]
 
 [[package]]
@@ -1244,18 +1125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p384"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,15 +1165,6 @@ checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
 dependencies = [
  "base64",
  "serde",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -1366,35 +1226,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
-dependencies = [
- "der 0.6.1",
- "pkcs8 0.9.0",
- "spki 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.8",
- "pkcs8 0.10.2",
- "spki 0.7.2",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -1403,8 +1241,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.8",
- "spki 0.7.2",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1553,27 +1391,26 @@ dependencies = [
  "clap",
  "clio",
  "data-url",
- "der 0.7.8",
+ "der",
  "etcd-client",
  "fn-error-context",
  "futures-util",
  "glob",
  "hmac",
- "jwt-simple",
  "lazy-regex",
  "lazy_static",
  "libc",
  "num-bigint",
  "p256",
  "pem 3.0.2",
- "pkcs1 0.7.5",
+ "pkcs1",
  "prost",
  "prost-build",
  "rand",
  "regex",
  "reqwest",
  "ring 0.17.5",
- "rsa 0.9.3",
+ "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1704,27 +1541,6 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
-dependencies = [
- "byteorder",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-iter",
- "num-traits",
- "pkcs1 0.4.1",
- "pkcs8 0.9.0",
- "rand_core",
- "signature 1.6.4",
- "smallvec",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
@@ -1734,11 +1550,11 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
+ "pkcs1",
+ "pkcs8",
  "rand_core",
- "signature 2.1.0",
- "spki 0.7.2",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -1796,9 +1612,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.8",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1892,16 +1708,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core",
-]
-
-[[package]]
-name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
@@ -1971,22 +1777,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.8",
+ "der",
 ]
 
 [[package]]
@@ -2670,8 +2466,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25eefca1d99701da3a57feb07e5079fc62abba059fc139e98c13bbb250f3ef29"
 dependencies = [
  "const-oid",
- "der 0.7.8",
- "spki 0.7.2",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2683,12 +2479,12 @@ dependencies = [
  "bcder",
  "bytes",
  "chrono",
- "der 0.7.8",
+ "der",
  "hex",
  "pem 2.0.1",
  "ring 0.16.20",
- "signature 2.1.0",
- "spki 0.7.2",
+ "signature",
+ "spki",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ futures-util = "0.3.28"
 rand = "0.8.5"
 hmac = "0.12.1"
 sha2 = "0.10.6"
-jwt-simple = "0.11.5"
-serde = { version = "1.0.163", features = ["rc"] }
+serde = { version = "1.0.163", features = ["rc", "derive"] }
 clap = { version = "4.4.2", features = ["derive"] }
 p256 = "0.13.2"
 tempfile = "3.5.0"

--- a/src/cluster_crypto/crypto_utils/jwt.rs
+++ b/src/cluster_crypto/crypto_utils/jwt.rs
@@ -1,0 +1,119 @@
+use crate::cluster_crypto::{
+    crypto_utils::{self, SigningKey},
+    keys::PublicKey,
+};
+use anyhow::{bail, Context, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD as base64_url, Engine as _};
+use std::{io::Write, process::Command};
+use x509_certificate::InMemorySigningKeyPair;
+
+pub(crate) fn verify(jwt: &str, public_key: &PublicKey) -> Result<bool> {
+    let pub_pem = public_key.pem()?.to_string();
+
+    let parts = jwt.split('.').collect::<Vec<_>>();
+    if parts.len() != 3 {
+        bail!("jwt not 3 parts");
+    }
+
+    let header_decoded = base64_url.decode(parts[0].as_bytes())?;
+    let signature_decoded = base64_url.decode(parts[2].as_bytes())?;
+
+    let header_payload = format!("{}.{}", parts[0], parts[1]);
+
+    let header_json = serde_json::from_slice::<serde_json::Value>(&header_decoded)?;
+
+    let alg = header_json
+        .get("alg")
+        .context("jwt missing alg")?
+        .as_str()
+        .context("alg not string")?;
+
+    if alg != "RS256" {
+        bail!("unsupported alg {}", alg);
+    }
+
+    let mut cert_file = tempfile::NamedTempFile::new()?;
+    cert_file.write_all(pub_pem.as_bytes())?;
+    cert_file.flush()?;
+
+    let mut signature_file = tempfile::NamedTempFile::new()?;
+    signature_file.write_all(signature_decoded.as_slice())?;
+    signature_file.flush()?;
+
+    let mut header_payload_file = tempfile::NamedTempFile::new()?;
+    header_payload_file.write_all(header_payload.as_bytes())?;
+    header_payload_file.flush()?;
+
+    let output = Command::new("openssl")
+        .arg("dgst")
+        .arg("-sha256")
+        .arg("-verify")
+        .arg(cert_file.path())
+        .arg("-signature")
+        .arg(signature_file.path())
+        .arg(header_payload_file.path())
+        .output()?;
+
+    Ok(output.status.success())
+}
+
+pub(crate) fn resign(jwt: &str, private_key: &SigningKey) -> Result<String> {
+    let parts = jwt.split('.').collect::<Vec<_>>();
+    if parts.len() != 3 {
+        return Ok(jwt.to_string());
+    }
+
+    let header_decoded = base64_url.decode(parts[0].as_bytes())?;
+    let payload = parts[1]; // No need to decode this, we're just passing it through
+
+    let mut header_json = serde_json::from_slice::<serde_json::Value>(&header_decoded)?;
+
+    let alg = header_json
+        .get("alg")
+        .context("jwt missing alg")?
+        .as_str()
+        .context("alg not string")?;
+
+    if alg != "RS256" {
+        bail!("unsupported alg {}", alg);
+    }
+
+    let (kid, pem_bytes) = match &private_key.in_memory_signing_key_pair {
+        InMemorySigningKeyPair::Ecdsa(_, _, _) => {
+            bail!("ecdsa unsupported");
+        }
+        InMemorySigningKeyPair::Ed25519(_) => {
+            bail!("ed unsupported");
+        }
+        InMemorySigningKeyPair::Rsa(_rsa_key_pair, bytes) => (
+            base64_url.encode(crypto_utils::sha256(bytes).context("calculating kid")?),
+            private_key.pkcs8_pem.clone(),
+        ),
+    };
+
+    header_json
+        .as_object_mut()
+        .context("headern not objecT")?
+        .insert("kid".to_string(), serde_json::Value::String(kid));
+
+    let header_json = serde_json::to_string(&header_json)?;
+
+    let header_payload = format!("{}.{}", base64_url.encode(header_json.as_bytes()), payload);
+
+    let mut header_payload_file = tempfile::NamedTempFile::new()?;
+    header_payload_file.write_all(header_payload.as_bytes())?;
+    header_payload_file.flush()?;
+
+    let mut pem_file = tempfile::NamedTempFile::new()?;
+    pem_file.write_all(pem_bytes.as_slice())?;
+
+    let output = Command::new("openssl")
+        .arg("dgst")
+        .arg("-sha256")
+        .arg("-sign")
+        .arg(pem_file.path())
+        .arg(header_payload_file.path())
+        .output()?;
+
+    Ok(format!("{}.{}", header_payload, base64_url.encode(output.stdout)))
+}

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -40,14 +40,7 @@ impl DistributedPrivateKey {
         let self_new_key_pair = rsa_key_pool.get(num_bits).context("RSA pool empty")?;
 
         for signee in &mut self.signees {
-            signee.regenerate(
-                &original_signing_public_key,
-                Some(&self_new_key_pair),
-                rsa_key_pool,
-                customizations,
-                None,
-                None,
-            )?;
+            signee.regenerate(Some(&self_new_key_pair), rsa_key_pool, customizations, None, None)?;
         }
 
         let regenerated_private_key: PrivateKey = (&self_new_key_pair.in_memory_signing_key_pair).try_into()?;

--- a/src/cluster_crypto/signee.rs
+++ b/src/cluster_crypto/signee.rs
@@ -2,7 +2,6 @@ use super::{
     cert_key_pair::{CertKeyPair, SerialNumberEdits, SkidEdits},
     crypto_utils::SigningKey,
     distributed_jwt::DistributedJwt,
-    keys,
 };
 use crate::{rsa_key_pool::RsaKeyPool, Customizations};
 use anyhow::{bail, Context, Result};
@@ -30,7 +29,6 @@ impl Serialize for Signee {
 impl Signee {
     pub(crate) fn regenerate(
         &mut self,
-        original_signing_public_key: &keys::PublicKey,
         new_signing_key: Option<&SigningKey>,
         rsa_key_pool: &mut RsaKeyPool,
         customizations: &Customizations,
@@ -48,7 +46,7 @@ impl Signee {
                 )?;
             }
             Self::Jwt(jwt) => match new_signing_key {
-                Some(key_pair) => (**jwt).borrow_mut().regenerate(original_signing_public_key, key_pair)?,
+                Some(key_pair) => (**jwt).borrow_mut().regenerate(key_pair)?,
                 None => {
                     bail!("Cannot regenerate a jwt without a signing key, regenerate may only be called on a signee that is a root cert-key-pair")
                 }


### PR DESCRIPTION
Drop overkill jwt_simple dependency, it was very annoying to use in our
context anyway. Replaced with `src/cluster_crypto/crypto_utils/jwt.rs`
which uses openssl to verify and sign JWTs.

I think performance may have took a hit with this change

Solves [MGMT-16095](https://issues.redhat.com//browse/MGMT-16095)