### PR TITLE
Allow user to optionally provide an infra ID

### DIFF
--- a/run_seed.sh
+++ b/run_seed.sh
@@ -58,7 +58,7 @@ cargo run --release -- \
     --cn-san-replace api.test-cluster.redhat.com:api.new-name.foo.com \
     --cn-san-replace *.apps.test-cluster.redhat.com:*.apps.new-name.foo.com \
     --cn-san-replace 192.168.127.10:192.168.127.11 \
-    --cluster-rename new-name:foo.com \
+    --cluster-rename new-name:foo.com:some-random-infra-id \
     --summary-file summary.yaml \
     --summary-file-clean summary_redacted.yaml \
     --extend-expiration

--- a/src/ocp_postprocess/cluster_domain_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename.rs
@@ -17,7 +17,11 @@ pub(crate) async fn rename_all(
 ) -> Result<(), anyhow::Error> {
     let cluster_domain = cluster_rename.cluster_domain();
     let cluster_name = cluster_rename.cluster_name.clone();
-    let generated_infra_id = rename_utils::generate_infra_id(&cluster_rename.cluster_name)?;
+
+    let generated_infra_id = match cluster_rename.infra_id.clone() {
+        Some(infra_id) => infra_id,
+        None => rename_utils::generate_infra_id(&cluster_rename.cluster_name).context("generating random infra ID")?,
+    };
 
     fix_etcd_resources(etcd_client, &cluster_domain, generated_infra_id.clone(), cluster_rename)
         .await

--- a/src/ocp_postprocess/cluster_domain_rename/params.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/params.rs
@@ -4,6 +4,7 @@ use anyhow::{ensure, Result};
 pub(crate) struct ClusterRenameParameters {
     pub(crate) cluster_name: String,
     pub(crate) cluster_base_domain: String,
+    pub(crate) infra_id: Option<String>,
 }
 
 impl ClusterRenameParameters {
@@ -11,17 +12,20 @@ impl ClusterRenameParameters {
         let parts = value.split(':').collect::<Vec<_>>();
 
         ensure!(
-            parts.len() == 2,
-            "expected exactly two parts separated by ':' in cluster rename argument, i.e. '<cluster-name>:<cluster-base-domain>', found {}",
+            parts.len() == 2 || parts.len() == 3,
+            "expected two or three parts separated by ':' in cluster rename argument, i.e. '<cluster-name>:<cluster-base-domain>:<infra-id> or <cluster-name>:<cluster-base-domain>', found {}",
             parts.len()
         );
 
         let cluster_name = parts[0].to_string();
         let cluster_base_domain = parts[1].to_string();
 
+        let infra_id = if parts.len() == 3 { Some(parts[2].to_string()) } else { None };
+
         Ok(Self {
             cluster_name,
             cluster_base_domain,
+            infra_id,
         })
     }
 


### PR DESCRIPTION
infra-id is not just a UUID, it's made up from the cluster name + some
random digits, and since recert takes care of doing a rename, it has to
take care of infra-id as well

During a regular OCP installation those digits are random

So IBI recert rename also does random (since we're pretending it's a
fresh cluster)

But IBU recert rename should use the infra-id from the original cluster,
it can't just add random digits.

This commit adds an option for the user to provide their own infra-id to
facilitate IBU

Solves [MGMT-16122](https://issues.redhat.com//browse/MGMT-16122)