### PR TITLE
Unsupported JWT algorithm should be a warning

### DIFF
--- a/src/cluster_crypto.rs
+++ b/src/cluster_crypto.rs
@@ -240,8 +240,11 @@ impl ClusterCryptoObjects {
                     &(**distributed_jwt).borrow().jwt.str,
                     &PublicKey::try_from(&(*last_signer).borrow().key)?,
                 )
-                .context("verifying last signer")?
-                {
+                .context(format!(
+                    "verifying last signer {} for jwt {}",
+                    (*last_signer).borrow().locations,
+                    (**distributed_jwt).borrow().locations
+                ))? {
                     maybe_signer = jwt::JwtSigner::PrivateKey(Rc::clone(last_signer));
                 }
             }
@@ -252,8 +255,11 @@ impl ClusterCryptoObjects {
                         &(**distributed_jwt).borrow().jwt.str,
                         &PublicKey::try_from(&(**distributed_private_key).borrow().key)?,
                     )
-                    .context("verifying private key signer")?
-                    {
+                    .context(format!(
+                        "verifying private key signer {} for jwt {}",
+                        (*distributed_private_key).borrow().locations,
+                        (**distributed_jwt).borrow().locations
+                    ))? {
                         maybe_signer = jwt::JwtSigner::PrivateKey(Rc::clone(distributed_private_key));
                         last_signer = Some(Rc::clone(distributed_private_key));
                         break;
@@ -268,8 +274,11 @@ impl ClusterCryptoObjects {
                             &(**distributed_jwt).borrow().jwt.str,
                             &PublicKey::try_from(&(**distributed_private_key).borrow().key)?,
                         )
-                        .context("verifying cert-key-pair signer")?
-                        {
+                        .context(format!(
+                            "verifying cert key pair signer {} for jwt {}",
+                            (*distributed_private_key).borrow().locations,
+                            (**distributed_jwt).borrow().locations
+                        ))? {
                             maybe_signer = jwt::JwtSigner::CertKeyPair(Rc::clone(cert_key_pair));
                             break;
                         }

--- a/src/cluster_crypto/crypto_utils/jwt.rs
+++ b/src/cluster_crypto/crypto_utils/jwt.rs
@@ -8,6 +8,10 @@ use std::{io::Write, process::Command};
 use x509_certificate::InMemorySigningKeyPair;
 
 pub(crate) fn verify(jwt: &str, public_key: &PublicKey) -> Result<bool> {
+    if let PublicKey::Ec(_) = public_key {
+        return Ok(false);
+    };
+
     let pub_pem = public_key.pem()?.to_string();
 
     let parts = jwt.split('.').collect::<Vec<_>>();
@@ -29,7 +33,8 @@ pub(crate) fn verify(jwt: &str, public_key: &PublicKey) -> Result<bool> {
         .context("alg not string")?;
 
     if alg != "RS256" {
-        bail!("unsupported alg {}", alg);
+        println!("WARNING: unsupported alg {}", alg);
+        return Ok(false);
     }
 
     let mut cert_file = tempfile::NamedTempFile::new()?;

--- a/src/cluster_crypto/keys.rs
+++ b/src/cluster_crypto/keys.rs
@@ -169,7 +169,7 @@ impl PublicKey {
     pub(crate) fn pem(&self) -> Result<pem::Pem> {
         Ok(match &self {
             PublicKey::Rsa(rsa_der_bytes) => pem::Pem::new("RSA PUBLIC KEY", rsa_der_bytes.as_ref()),
-            PublicKey::Ec(pem_bytes) => pem::parse(pem_bytes).context("ec bytes as pem").context("bytes as PEM")?,
+            PublicKey::Ec(pem_bytes) => pem::parse(pem_bytes).context(format!("ec bytes to pem {:?}", pem_bytes))?,
         })
     }
 }


### PR DESCRIPTION
Otherwise we'll trip like we did in b3695533a8e0a8498c9ea72d94365f3b4aa8267c

Also pretend all EC keys are failing to verify JWTs for now