### PR TITLE
PEM bundle editing should preserve content between PEM objects

### DIFF
--- a/src/cluster_crypto/pem_utils.rs
+++ b/src/cluster_crypto/pem_utils.rs
@@ -1,17 +1,106 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 
-pub(crate) fn pem_bundle_replace_pem_at_index(original_pem_bundle: String, pem_index: u64, newpem: &pem::Pem) -> Result<String> {
-    let pems = pem::parse_many(original_pem_bundle.clone())?;
-    let mut newpems = vec![];
-    for (i, pem) in pems.iter().enumerate() {
-        if i == usize::try_from(pem_index)? {
-            newpems.push(newpem.clone());
-        } else {
-            newpems.push(pem.clone());
+pub fn pem_bundle_line_ending(pem_bundle: &str) -> Result<pem::LineEnding> {
+    enum State {
+        Start,
+        CR,
+        LF,
+    }
+
+    let mut state = State::Start;
+
+    let mut crlf_count = 0;
+    let mut lf_count = 0;
+
+    for c in pem_bundle.chars() {
+        match state {
+            State::Start => match c {
+                '\r' => state = State::CR,
+                '\n' => state = State::LF,
+                _ => (),
+            },
+            State::CR => match c {
+                '\r' => state = State::CR,
+                '\n' => {
+                    state = State::Start;
+                    crlf_count += 1;
+                }
+                _ => (),
+            },
+            State::LF => match c {
+                '\r' => {
+                    state = State::CR;
+                    crlf_count += 1;
+                }
+                '\n' => {
+                    state = State::LF;
+                    lf_count += 1;
+                }
+                _ => state = State::Start,
+            },
         }
     }
-    Ok(pem::encode_many_config(
-        &newpems,
-        pem::EncodeConfig::new().set_line_ending(pem::LineEnding::LF),
-    ))
+
+    ensure!(
+        crlf_count == 0 || lf_count == 0,
+        format!("pem bundle has mixed line endings, crlf_count {} lf_count {}", crlf_count, lf_count)
+    );
+
+    if crlf_count > 0 {
+        Ok(pem::LineEnding::CRLF)
+    } else {
+        Ok(pem::LineEnding::LF)
+    }
+}
+
+pub(crate) fn pem_bundle_replace_pem_at_index(original_pem_bundle: String, pem_index: u64, newpem: &pem::Pem) -> Result<String> {
+    let original_line_endings = pem_bundle_line_ending(original_pem_bundle.as_str())?;
+
+    let original_pem = {
+        let pems = pem::parse_many(original_pem_bundle.clone())?;
+        ensure!(
+            usize::try_from(pem_index)? < pems.len(),
+            format!("pem_index {} out of range {}", pem_index, pems.len())
+        );
+        pem::encode_config(
+            &pems[usize::try_from(pem_index)?],
+            pem::EncodeConfig::new().set_line_ending(original_line_endings),
+        )
+    };
+
+    let found_indices = original_pem_bundle.as_str().match_indices(&original_pem).collect::<Vec<_>>();
+
+    ensure!(
+        !found_indices.is_empty(),
+        format!("pem {} not found in pem bundle {}", original_pem, original_pem_bundle)
+    );
+
+    ensure!(
+        found_indices.len() == 1,
+        format!(
+            "pem_index {} not unique in pem bundle, found in indices {:?}",
+            pem_index, found_indices
+        )
+    );
+    let new_bundle = original_pem_bundle.replace(
+        &original_pem,
+        &pem::encode_config(newpem, pem::EncodeConfig::new().set_line_ending(original_line_endings)).to_string(),
+    );
+
+    let new_line_endings = pem_bundle_line_ending(new_bundle.as_str())?;
+
+    let line_endings_match = matches!(
+        (original_line_endings, new_line_endings),
+        (pem::LineEnding::LF, pem::LineEnding::LF) | (pem::LineEnding::CRLF, pem::LineEnding::CRLF)
+    );
+
+    ensure!(
+        line_endings_match,
+        format!(
+            "line endings changed from {:?} to {:?} when replacing pem",
+            original_line_endings, new_line_endings,
+        )
+    );
+
+    Ok(new_bundle)
 }


### PR DESCRIPTION
Replacing is now done by naive search-and-replace on the original bundle
string rather than by parsing and re-emitting the bundle (which loses
the content between the PEM objects in the process)