### PR TITLE
Sync webhook-authenticator static secret files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde_json = "1.0.93"
+serde_json = { version = "1.0.93", features = ["preserve_order"] }
 serde_yaml = "0.9.22"
 glob = "0.3.1"
 base64 = "0.21.0"


### PR DESCRIPTION
The webhook authenticator secret has a kubeConfig field that is too
complicated to handle in recert. We could simply delete it and it will
be reconciled, but that's a bit too slow for us as it causes a
kube-apiserver rollout. To speed things up, we'll just "reconcile" it
ourselves by copying the kubeConfig contents from the kubeConfig file on
disk that we already processed with recert.

Also enable the preserve_order feature of serde_json to make sure field
order is maintained, because those differences also cause rollouts

________________

Older revisions are deleted from etcd, only the latest revision is synced:

![image](https://github.com/rh-ecosystem-edge/recert/assets/10882062/a2c49e98-7225-4c01-89de-47e48142ae99)
