### PR TITLE
Pretty `oauth-metadata`

### DIFF
--- a/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
@@ -564,7 +564,7 @@ pub(crate) async fn fix_authentication_system_metadata(
         .context("data not an object")?
         .insert(
             "oauthMetadata".to_string(),
-            serde_json::Value::String(serde_json::to_string(&config).context("serializing config.yaml")?),
+            serde_json::Value::String(serde_json::to_string_pretty(&config).context("serializing config.yaml")?),
         )
         .context("could not find original oauthMetadata")?;
 


### PR DESCRIPTION
The original `oauth-metadata` file has a pretty JSON, so it should stay
pretty to avoid rollouts