### PR TITLE
Use unauthenticated RH registry for prow Dockerfile

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi:latest as builder
+FROM registry.access.redhat.com/ubi9/ubi:latest as builder
 
 RUN INSTALL_PKGS=" \
       gcc-c++ \


### PR DESCRIPTION
In the current CI [dockerfile_literal](https://github.com/openshift/release/blob/master/ci-operator/config/rh-ecosystem-edge/recert/rh-ecosystem-edge-recert-main.yaml#L29), `registry.redhat.io` is used and it supports only authenticated access, but it worked so far because of the respective [from](https://github.com/openshift/release/blob/master/ci-operator/config/rh-ecosystem-edge/recert/rh-ecosystem-edge-recert-main.yaml#L57) directive. 

This PR replaces the authenticated `registry.redhat.io` with the unauthenticated `registry.access.redhat.com`, in order to have successful builds with the `Dockerfile.prow` container file.

The following is the CI [error](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/47035/rehearse-47035-pull-ci-rh-ecosystem-edge-recert-v0-cargo-clippy/1738138905951080448) that lead me to this change:

```log
ERRO[2023-12-22T10:09:04Z] Some steps failed:                           
ERRO[2023-12-22T10:09:04Z] * could not run steps: step recert-check failed: error occurred handling build recert-check-amd64: the build recert-check-amd64 failed after 27s with reason ManageDockerfileFailed: Failed to prepare the dockerfile for the build. 
INFO[2023-12-22T10:09:04Z] Reporting job state 'failed' with reason 'executing_graph:step_failed:building_project_image' 
```