### PR TITLE
MGMT-16426: add hostname change to recert's OCP post-process

### DIFF
--- a/run_seed.sh
+++ b/run_seed.sh
@@ -64,6 +64,7 @@ cargo run --release -- \
     --cn-san-replace *.apps.seed.redhat.com:*.apps.new-name.foo.com \
     --cn-san-replace 192.168.126.10:192.168.127.11 \
     --cluster-rename new-name:foo.com:some-random-infra-id \
+    --hostname test.hostname \
     --summary-file summary.yaml \
     --summary-file-clean summary_redacted.yaml \
     --extend-expiration

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,7 @@ pub(crate) struct RecertConfig {
     pub(crate) static_files: Vec<ConfigPath>,
     pub(crate) customizations: Customizations,
     pub(crate) cluster_rename: Option<ClusterRenameParameters>,
+    pub(crate) hostname: Option<String>,
     pub(crate) threads: Option<usize>,
     pub(crate) regenerate_server_ssh_keys: Option<ConfigPath>,
     pub(crate) summary_file: Option<ConfigPath>,
@@ -189,6 +190,11 @@ impl RecertConfig {
             None => None,
         };
 
+        let hostname = match value.get("hostname") {
+            Some(value) => Some(value.as_str().context("hostname must be a string")?.to_string()),
+            None => None,
+        };
+
         let threads = match value.get("threads") {
             Some(value) => Some(
                 value
@@ -243,6 +249,7 @@ impl RecertConfig {
                 force_expire,
             },
             cluster_rename,
+            hostname,
             threads,
             regenerate_server_ssh_keys,
             summary_file,
@@ -284,6 +291,7 @@ impl RecertConfig {
                 force_expire: cli.force_expire,
             },
             cluster_rename: cli.cluster_rename,
+            hostname: cli.hostname,
             threads: cli.threads,
             regenerate_server_ssh_keys: cli.regenerate_server_ssh_keys.map(ConfigPath::from),
             summary_file: cli.summary_file.map(ConfigPath::from),

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -35,6 +35,11 @@ pub(crate) struct Cli {
     #[clap(long, value_parser = ClusterRenameParameters::cli_parse)]
     pub(crate) cluster_rename: Option<ClusterRenameParameters>,
 
+    /// If given, the cluster resources that include the hostname will be modified to use this one
+    /// instead.
+    #[clap(long)]
+    pub(crate) hostname: Option<String>,
+
     /// A list of CNs and the private keys to use for their certs. By default, new keys will be
     /// generated for all regenerated certificates, this option allows you to use existing keys
     /// instead. Must come in pairs of CN and private key file path, separated by a space. For

--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -16,12 +16,14 @@ use sha2::Digest;
 use std::{collections::HashSet, sync::Arc};
 
 pub(crate) mod cluster_domain_rename;
+pub(crate) mod hostname_rename;
 mod fnv;
 
 /// Perform some OCP-related post-processing to make some OCP operators happy
 pub(crate) async fn ocp_postprocess(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_rename_params: &Option<ClusterRenameParameters>,
+    hostname: &Option<String>,
     static_dirs: &Vec<ConfigPath>,
     static_files: &Vec<ConfigPath>,
 ) -> Result<()> {
@@ -45,6 +47,12 @@ pub(crate) async fn ocp_postprocess(
         cluster_rename(in_memory_etcd_client, cluster_rename_params, static_dirs, static_files)
             .await
             .context("renaming cluster")?;
+    }
+
+    if let Some(hostname) = hostname {
+        hostname_rename(in_memory_etcd_client, hostname, static_dirs, static_files)
+            .await
+            .context("renaming hostname")?;
     }
 
     fix_deployment_dep_annotations(
@@ -352,6 +360,21 @@ pub(crate) async fn cluster_rename(
     }
 
     cluster_domain_rename::rename_all(etcd_client, cluster_rename, static_dirs, static_files)
+        .await
+        .context("renaming all")?;
+
+    Ok(())
+}
+
+pub(crate) async fn hostname_rename(
+    in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
+    hostname: &str,
+    static_dirs: &Vec<ConfigPath>,
+    static_files: &Vec<ConfigPath>,
+) -> Result<()> {
+    let etcd_client = in_memory_etcd_client;
+
+    hostname_rename::rename_all(etcd_client, hostname, static_dirs, static_files)
         .await
         .context("renaming all")?;
 

--- a/src/ocp_postprocess/hostname_rename.rs
+++ b/src/ocp_postprocess/hostname_rename.rs
@@ -1,0 +1,54 @@
+use crate::{
+    config::ConfigPath,
+    k8s_etcd::{InMemoryK8sEtcd},
+};
+use anyhow::{Context, Result};
+use std::{sync::Arc};
+
+mod etcd_rename;
+
+pub(crate) async fn rename_all(
+    etcd_client: &Arc<InMemoryK8sEtcd>,
+    hostname: &str,
+    _static_dirs: &Vec<ConfigPath>,
+    _static_files: &Vec<ConfigPath>,
+) -> Result<(), anyhow::Error> {
+
+    fix_etcd_resources(etcd_client, hostname)
+        .await
+        .context("renaming etcd resources")?;
+
+    Ok(())
+}
+
+async fn fix_etcd_resources(
+    etcd_client: &Arc<InMemoryK8sEtcd>,
+    hostname: &str,
+) -> Result<(), anyhow::Error> {
+    etcd_rename::fix_etcd_all_certs(etcd_client, hostname)
+        .await
+        .context("fixing etcd-all-certs")?;
+    etcd_rename::fix_etcd_secrets(etcd_client, hostname)
+        .await
+        .context("fixing etcd secrets")?;
+    etcd_rename::fix_etcd_pod(etcd_client, hostname)
+        .await
+        .context("fixing etcd-pod")?;
+    etcd_rename::fix_etcd_scripts(etcd_client, hostname)
+        .await
+        .context("fixing etcd-scripts")?;
+    etcd_rename::fix_restore_etcd_pod(etcd_client, hostname)
+        .await
+        .context("fixing restore-etcd-pod")?;
+    etcd_rename::fix_kubeapiservers_cluster(etcd_client, hostname)
+        .await
+        .context("fixing kubeapiservers/cluster")?;
+    etcd_rename::fix_kubeschedulers_cluster(etcd_client, hostname)
+        .await
+        .context("fixing kubeschedulers/cluster")?;
+    etcd_rename::fix_kubecontrollermanagers_cluster(etcd_client, hostname)
+        .await
+        .context("fixing kubecontrollermanagers/cluster")?;
+
+    Ok(())
+}

--- a/src/ocp_postprocess/hostname_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/hostname_rename/etcd_rename.rs
@@ -1,0 +1,267 @@
+use crate::{
+    cluster_crypto::locations::K8sResourceLocation,
+    k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
+};
+use anyhow::{Context, Result};
+use futures_util::future::join_all;
+use serde_json::{Map, Value};
+use std::{sync::Arc};
+
+pub(crate) async fn fix_etcd_all_certs(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+    join_all(
+        etcd_client
+            .list_keys("secrets/openshift-etcd/etcd-all-certs")
+            .await?
+            .into_iter()
+            .map(|key| async move {
+                let etcd_result = etcd_client
+                    .get(key.clone())
+                    .await
+                    .with_context(|| format!("getting key {:?}", key))?
+                    .context("key disappeared")?;
+                let value: Value = serde_yaml::from_slice(etcd_result.value.as_slice())
+                    .with_context(|| format!("deserializing value of key {:?}", key,))?;
+                let k8s_resource_location = K8sResourceLocation::try_from(&value)?;
+
+                let mut secret = get_etcd_json(etcd_client, &k8s_resource_location)
+                    .await?
+                    .context("getting secret")?;
+
+                let data = &mut secret
+                    .pointer_mut("/data")
+                    .context("no /data")?
+                    .as_object_mut()
+                    .context("data not an object")?;
+
+                let keys = vec![
+                    ("etcd-peer-", ".crt"),
+                    ("etcd-peer-", ".key"),
+                    ("etcd-serving-", ".crt"),
+                    ("etcd-serving-", ".key"),
+                    ("etcd-serving-metrics-", ".crt"),
+                    ("etcd-serving-metrics-", ".key"),
+                ];
+                // TODO: we ignore errors, but maybe we shouldn't?
+                let _ = keys
+                    .into_iter()
+                    .filter_map(|(prefix, suffix)| replace_data_field(data, prefix, suffix, hostname, key.to_owned()).ok())
+                    .collect::<Vec<_>>();
+
+                put_etcd_yaml(etcd_client, &k8s_resource_location, secret)
+                    .await
+                    .context(format!("could not put etcd key: {}", key))?;
+
+                Ok(())
+            }),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    Ok(())
+}
+
+fn replace_data_field(data: &mut Map<String, Value>, prefix: &str, suffix: &str, hostname: &str, key: String) -> Result<()> {
+    let (key, value) = data
+        .into_iter()
+        .filter(|(k, _v)| k.starts_with(prefix) && k.ends_with(suffix))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .next()
+        .context(format!("no {}*{} key in {}", prefix, suffix, key))?
+        .clone();
+    data.insert(format!("{}{}{}", prefix, hostname, suffix), value);
+    data.remove(&key);
+
+    Ok(())
+}
+
+pub(crate) async fn fix_etcd_secrets(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+    join_all(
+        etcd_client
+            .list_keys("secrets/openshift-etcd/")
+            .await?
+            .into_iter()
+            .filter(|key| {
+                vec![
+                    "etcd-peer-",
+                    "etcd-serving-",
+                    "etcd-serving-metrics-",
+                ]
+                .into_iter()
+                .any(|prefix| key.contains(prefix))
+            })
+            .map(|key| async move {
+                let etcd_result = etcd_client
+                    .get(key.clone())
+                    .await
+                    .with_context(|| format!("getting key {:?}", key))?
+                    .context("key disappeared")?;
+                let value: Value = serde_yaml::from_slice(etcd_result.value.as_slice())
+                    .with_context(|| format!("deserializing value of key {:?}", key,))?;
+                let mut k8s_resource_location = K8sResourceLocation::try_from(&value)?;
+
+                let mut secret = get_etcd_json(etcd_client, &k8s_resource_location)
+                    .await?
+                    .context("getting secret")?;
+                let metadata = &mut secret
+                    .pointer_mut("/metadata")
+                    .context("no /metadata")?
+                    .as_object_mut()
+                    .context("data not an object")?;
+                let (_, previous_name) = key.rsplit_once('/').unwrap();
+                // TODO: what if the hostname contains a `-`
+                let mut parts = previous_name.split('-').collect::<Vec<&str>>();
+                if let Some(last) = parts.last_mut() {
+                    *last = hostname;
+                }
+                let name: String = parts.join("-");
+                metadata.insert("name".to_string(), serde_json::Value::String(name.clone()));
+                k8s_resource_location.name = name.to_string();
+                put_etcd_yaml(etcd_client, &k8s_resource_location, secret).await?;
+
+                etcd_client.delete(&key).await.context(format!("deleting {}", key))?;
+
+                Ok(())
+            }),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    Ok(())
+}
+
+// TODO: needs change in the data.install-config[metadata.name]
+// TODO: although this is probably the cluster name and not the hostname?
+// pub(crate) async fn fix_cluster_config_v1(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+//     let k8s_resource_location = K8sResourceLocation::new(Some("openshift-etcd"), "ConfigMap", "cluster-config-v1", "v1");
+//     let mut configmap = get_etcd_json(etcd_client, &k8s_resource_location)
+//         .await?
+//         .context("getting configmap")?;
+//     Ok(())
+// }
+
+// /kubernetes.io/configmaps/openshift-etcd/etcd-pod
+// /kubernetes.io/configmaps/openshift-etcd/etcd-pod-2
+// TODO: data["pod.yaml"] - env.[NODE_seed_ETCD_NAME,NODE_seed_ETCD_URL_HOST,NODE_seed_IP]
+// TODO: we need to account for unsupported chars in the hostname being an env var name
+//       e.g. "another-hostname" -> "another_hostname" when used in an env var name
+pub(crate) async fn fix_etcd_pod(etcd_client: &Arc<InMemoryK8sEtcd>, _hostname: &str) -> Result<()> {
+    join_all(
+        etcd_client
+            .list_keys("configmaps/openshift-etcd/etcd-pod")
+            .await?
+            .into_iter()
+            .map(|key| async move {
+                let etcd_result = etcd_client
+                    .get(key.clone())
+                    .await
+                    .with_context(|| format!("getting key {:?}", key))?
+                    .context("key disappeared")?;
+                let value: Value = serde_yaml::from_slice(etcd_result.value.as_slice())
+                    .with_context(|| format!("deserializing value of key {:?}", key,))?;
+                let k8s_resource_location = K8sResourceLocation::try_from(&value)?;
+
+                let mut configmap = get_etcd_json(etcd_client, &k8s_resource_location)
+                    .await?
+                    .context("getting secret")?;
+
+                let _data = &mut configmap
+                    .pointer_mut("/data")
+                    .context("no /data")?
+                    .as_object_mut()
+                    .context("data not an object")?;
+
+                // TODO: implement - replace the hostname
+
+                put_etcd_yaml(etcd_client, &k8s_resource_location, configmap).await?;
+
+                Ok(())
+            }),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    Ok(())
+}
+
+pub(crate) async fn fix_etcd_scripts(etcd_client: &Arc<InMemoryK8sEtcd>, _hostname: &str) -> Result<()> {
+    let k8s_resource_location = K8sResourceLocation::new(Some("openshift-etcd"), "ConfigMap", "etcd-scripts", "v1");
+    let mut _configmap = get_etcd_json(etcd_client, &k8s_resource_location)
+        .await?
+        .context("getting configmap")?;
+    // TODO: implement
+    Ok(())
+}
+
+pub(crate) async fn fix_restore_etcd_pod(etcd_client: &Arc<InMemoryK8sEtcd>, _hostname: &str) -> Result<()> {
+    let k8s_resource_location = K8sResourceLocation::new(Some("openshift-etcd"), "ConfigMap", "etcd-scripts", "v1");
+    let mut _configmap = get_etcd_json(etcd_client, &k8s_resource_location)
+        .await?
+        .context("getting configmap")?;
+    // TODO: implement
+    Ok(())
+}
+
+pub(crate) async fn fix_kubeapiservers_cluster(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+    let k8s_resource_location = K8sResourceLocation::new(None, "KubeAPIServer", "cluster", "operator.openshift.io/v1");
+    let mut cluster = get_etcd_json(etcd_client, &k8s_resource_location)
+        .await?
+        .context("getting kubeapiservers/cluster")?;
+
+    replace_node_status_name(&mut cluster, hostname)
+        .context("could not replace nodeName for kubeapiservers/cluster")?;
+
+    put_etcd_yaml(etcd_client, &k8s_resource_location, cluster).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn fix_kubeschedulers_cluster(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+    let k8s_resource_location = K8sResourceLocation::new(None, "KubeScheduler", "cluster", "operator.openshift.io/v1");
+    let mut cluster = get_etcd_json(etcd_client, &k8s_resource_location)
+        .await?
+        .context("getting kubeschedulers/cluster")?;
+
+    replace_node_status_name(&mut cluster, hostname)
+        .context("could not replace nodeName for kubeschedulers/cluster")?;
+
+    put_etcd_yaml(etcd_client, &k8s_resource_location, cluster).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn fix_kubecontrollermanagers_cluster(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) -> Result<()> {
+    let k8s_resource_location = K8sResourceLocation::new(None, "KubeControllerManager", "cluster", "operator.openshift.io/v1");
+    let mut cluster = get_etcd_json(etcd_client, &k8s_resource_location)
+        .await?
+        .context("getting kubecontrollermanagers/cluster")?;
+
+    replace_node_status_name(&mut cluster, hostname)
+        .context("could not replace nodeName for kubecontrollermanagers/cluster")?;
+
+    put_etcd_yaml(etcd_client, &k8s_resource_location, cluster).await?;
+
+    Ok(())
+}
+
+fn replace_node_status_name(cluster: &mut Value, hostname: &str) -> Result<()> {
+    let node_statuses = &mut cluster
+        .pointer_mut("/status/nodeStatuses")
+        .context("no /status/nodeStatuses")?
+        .as_array_mut()
+        .context("/status/nodeStatuses not an array")?;
+
+    node_statuses
+        .iter_mut()
+        .for_each(|status: &mut Value| {
+            status
+                .as_object_mut()
+                .unwrap()
+                .insert("nodeName".to_string(), Value::String(hostname.to_string()));
+        });
+
+    Ok(())
+}
+

--- a/src/recert.rs
+++ b/src/recert.rs
@@ -61,6 +61,7 @@ pub(crate) async fn run(
         Arc::clone(&in_memory_etcd_client),
         cluster_crypto,
         &parsed_cli.cluster_rename,
+        &parsed_cli.hostname,
         &parsed_cli.static_dirs,
         &parsed_cli.static_files,
         parsed_cli.regenerate_server_ssh_keys.as_deref(),
@@ -121,6 +122,7 @@ async fn finalize(
     in_memory_etcd_client: Arc<InMemoryK8sEtcd>,
     cluster_crypto: &mut ClusterCryptoObjects,
     cluster_rename: &Option<ClusterRenameParameters>,
+    hostname: &Option<String>,
     static_dirs: &Vec<ConfigPath>,
     static_files: &Vec<ConfigPath>,
     regenerate_server_ssh_keys: Option<&Path>,
@@ -136,7 +138,7 @@ async fn finalize(
 
     let start = std::time::Instant::now();
     if in_memory_etcd_client.etcd_client.is_some() {
-        ocp_postprocess(&in_memory_etcd_client, cluster_rename, static_dirs, static_files)
+        ocp_postprocess(&in_memory_etcd_client, cluster_rename, hostname, static_dirs, static_files)
             .await
             .context("performing ocp specific post-processing")?;
     }


### PR DESCRIPTION
This PR adds the changes required to the `ocp_postprocess` module, in order to skip the unnecessary and time-consuming OCP control-plane component rollouts. The latter get triggered by the node's `hostname` change, which occurs when applying an IBU seed image onto the target SNO.

The changes are:

- [x] add a new recert configuration argument of type `string`, i.e. `--hostname` with which the new `hostname` is provided
    - [ ] we might need to also replace the `NODE_IP` in the etcd related `configmaps`, in addition to the `hostname`, which is currently done in the filesystem by the LCA post-pivot. It's probably a good idea to do it here, so that we can change it both in etcd and the filesystem. In that sense, this argument could be refactored to `--hostname-rename <hostname>:<IP>` (?)
- [x] add a `hostname_rename` mod, which implements the following changes:
    - [ ] replace all occurrences of the previous (seed node) `hostname` in `etcd`
        - [x] `secrets/openshift-etcd/etcd-all-certs` and its revisions
        - [x] `operator.openshift.io/kubeapiservers/cluster`
        - [x]  `operator.openshift.io/kubecontrollermanagers/cluster`
        - [x]  `operator.openshift.io/kubeschedulers/cluster`
        - [x] `secrets/openshift-etcd/etcd-peer` and its revisions
        - [x] `secrets/openshift-etcd/etcd-serving`
        - [x] `secrets/openshift-etcd/etcd-serving-metrics`
        - [ ] `configmaps/openshift-etcd/etcd-pod` and its revisions
        - [ ] `configmaps/openshift-etcd/restore-etcd-pod`
        - [ ] `configmaps/openshift-etcd/etcd-scripts`
    - [ ] replace all occurrences of the previous (seed node) `hostname` in the filesystem
        - [ ] `/etc/kubernetes/static-pod-resources/etcd-*` env var names and values of env vars, i.e. `s/NODE_<hostname>/NODE_<new-hostname>/g; s/<hostname/<new-hostname>/g`
        - [ ] `/etc/kubernetes/manifests/etcd-*` env var names and env var values, i.e. `s/NODE_<hostname>/NODE_<new-hostname>/g; s/<hostname>/<new-hostname>/g`
        - [ ] `/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*`, i.e. `s/--node-name=<hostname>/--node-name=<new-hostname>/g`
        - [ ] `/etc/kubernetes/static-pod-resources/etcd-certs/secrets/etcd-all-certs/*.{crt,key}`
        - [ ] `/etc/kubernetes/static-pod-resources/etcd-member/etcd-all-certs/*.{crt,key}`
        - [ ] `/etc/kubernetes/static-pod-resources/etcd-pod-*/secrets/etcd-all-certs/*.{crt,key}`
- [ ] replace `hostname in `etcd` keys and values, that are irrelevant to skipping the control-plane component rollouts but still useful in order to not leave any leftovers when moving to the seed image to the target SNO 
 