### PR TITLE
Fix kubeconfig YAML serialization in etcd

### DIFF
--- a/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
@@ -1046,11 +1046,8 @@ pub(crate) async fn fix_kcm_kubeconfig(etcd_client: &Arc<InMemoryK8sEtcd>, clust
                     .context("compiling regex")?
                     .replace_all(kubeconfig, format!("$prefix.{cluster_domain}:$port").as_str());
 
-                data.insert(
-                    "kubeconfig".to_string(),
-                    serde_json::Value::String(serde_yaml::to_string(&kubeconfig).context("serializing kubeconfig")?),
-                )
-                .context("could not find original kubeconfig")?;
+                data.insert("kubeconfig".to_string(), serde_json::Value::String(kubeconfig.to_string()))
+                    .context("could not find original kubeconfig")?;
 
                 put_etcd_yaml(etcd_client, &k8s_resource_location, configmap).await?;
 


### PR DESCRIPTION
After switching to search and replace for the kubeconfig field in the respective `kube-controller-manager` and `kube-scheduler` `ConfigMaps`, we shouldn't serialize the edited `kubeconfig` field to YAML, as it includes an additional `|` character. The latter doesn't lead to an error, but it does lead to additional rollout triggers for these components.

Example `kubeconfig` field with the additional `|`:

```json
"data": {
        "kubeconfig": "|\n  apiVersion: v1\n  clusters:\n    - cluster:\n        certificate-authority: /etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\n        server: https://api-int.another-name.another.domain:6443\n      name: lb-int\n  contexts:\n    - context:\n        cluster: lb-int\n        user: kube-scheduler\n      name: kube-scheduler\n  current-context: kube-scheduler\n  kind: Config\n  preferences: {}\n  users:\n    - name: kube-scheduler\n      user:\n        client-certificate: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.crt\n        client-key: /etc/kubernetes/static-pod-certs/secrets/kube-scheduler-client-cert-key/tls.key\n"
    }
```