### PR TITLE
MGMT-16780: rename node name in OCP hostname post-process

### DIFF
--- a/src/cluster_crypto/locations.rs
+++ b/src/cluster_crypto/locations.rs
@@ -51,7 +51,7 @@ lazy_static! {
             ("kubescheduler", "kubeschedulers"),
             ("bmceventsubscription", "bmceventsubscriptions"),
             ("imagedigestmirrorset", "imagedigestmirrorsets"),
-            ("node", "nodes"),
+            ("node", "minions"),
             ("openshiftapiserver", "openshiftapiservers"),
             ("ingresscontroller", "ingresscontrollers"),
             ("machineconfigpool", "machineconfigpools"),

--- a/src/etcd_encoding.rs
+++ b/src/etcd_encoding.rs
@@ -4,7 +4,7 @@ use super::protobuf_gen::{
         api::{
             admissionregistration::v1::{MutatingWebhookConfiguration, ValidatingWebhookConfiguration},
             apps::v1::{DaemonSet, Deployment},
-            core::v1::{ConfigMap, Secret},
+            core::v1::{ConfigMap, Node, Secret},
         },
         apimachinery::pkg::runtime::{TypeMeta, Unknown},
     },
@@ -51,6 +51,7 @@ k8s_type!(RouteWithMeta, Route);
 k8s_type!(DaemonsSetWithMeta, DaemonSet);
 k8s_type!(DeploymentWithMeta, Deployment);
 k8s_type!(ConfigMapWithMeta, ConfigMap);
+k8s_type!(NodeWithMeta, Node);
 k8s_type!(SecretWithMeta, Secret);
 k8s_type!(ValidatingWebhookConfigurationWithMeta, ValidatingWebhookConfiguration);
 k8s_type!(MutatingWebhookConfigurationWithMeta, MutatingWebhookConfiguration);
@@ -69,6 +70,7 @@ pub(crate) async fn decode(data: &[u8]) -> Result<Vec<u8>> {
         "Deployment" => serde_json::to_vec(&DeploymentWithMeta::try_from(unknown)?)?,
         "DaemonSet" => serde_json::to_vec(&DaemonsSetWithMeta::try_from(unknown)?)?,
         "ConfigMap" => serde_json::to_vec(&ConfigMapWithMeta::try_from(unknown)?)?,
+        "Node" => serde_json::to_vec(&NodeWithMeta::try_from(unknown)?)?,
         "Secret" => serde_json::to_vec(&SecretWithMeta::try_from(unknown)?)?,
         "ValidatingWebhookConfiguration" => serde_json::to_vec(&ValidatingWebhookConfigurationWithMeta::try_from(unknown)?)?,
         "MutatingWebhookConfiguration" => serde_json::to_vec(&MutatingWebhookConfigurationWithMeta::try_from(unknown)?)?,
@@ -90,6 +92,7 @@ pub(crate) async fn encode(data: &[u8]) -> Result<Vec<u8>> {
     result.extend(
         match kind {
             "ConfigMap" => Unknown::from(serde_json::from_slice::<ConfigMapWithMeta>(data)?),
+            "Node" => Unknown::from(serde_json::from_slice::<NodeWithMeta>(data)?),
             "Route" => Unknown::from(serde_json::from_slice::<RouteWithMeta>(data)?),
             "Secret" => Unknown::from(serde_json::from_slice::<SecretWithMeta>(data)?),
             "Deployment" => Unknown::from(serde_json::from_slice::<DeploymentWithMeta>(data)?),

--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -396,7 +396,6 @@ pub(crate) async fn cluster_rename(
         "tuned.openshift.io/profiles",
         "csinodes/",
         "ptp.openshift.io/nodeptpdevices/",
-        "minions/",
         "sriovnetwork.openshift.io/sriovnetworknodestates/",
         // Delete all events as they contain the name
         "events/",
@@ -410,6 +409,8 @@ pub(crate) async fn cluster_rename(
         "replicasets/",
         // Delete ovnkube-node daemonset as it has cluster name in bash script
         "daemonsets/openshift-ovn-kubernetes/ovnkube-node",
+        // Delete network-node-identity daemonset as it has cluster domain in its webhook container
+        "daemonsets/openshift-network-node-identity/network-node-identity",
     ]
     .iter()
     {

--- a/src/ocp_postprocess/hostname_rename.rs
+++ b/src/ocp_postprocess/hostname_rename.rs
@@ -98,6 +98,9 @@ async fn fix_etcd_resources(etcd_client: &Arc<InMemoryK8sEtcd>, hostname: &str) 
     etcd_rename::fix_etcds_cluster(etcd_client, hostname)
         .await
         .context("fixing etcds/cluster")?;
+    etcd_rename::fix_node_name(etcd_client, &original_hostname, hostname)
+        .await
+        .context("fixing node name")?;
 
     Ok(original_hostname)
 }


### PR DESCRIPTION
This change adds a step to the OCP hostname post-process. Specifically, it renames the node object and sets its hostname address to the hostname defined by the --hostname arg.

Related LCA PR: https://github.com/openshift-kni/lifecycle-agent/pull/290