### PR TITLE
MGMT-17058: Fix IPv6 replacement by adding brackets when necessary 

### DIFF
--- a/src/ocp_postprocess/cluster_domain_rename/rename_utils.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/rename_utils.rs
@@ -110,6 +110,14 @@ pub(crate) fn fix_api_server_arguments_ip(config: &mut Value, original_ip: &str,
         .context("etcd-servers not an array")?
         .clone();
 
+    let original_ip = if original_ip.contains(':') {
+        format!("[{original_ip}]")
+    } else {
+        original_ip.to_string()
+    };
+
+    let ip = if ip.contains(':') { format!("[{ip}]") } else { ip.to_string() };
+
     let new_etcd_servers = original_etcd_servers
         .iter()
         .map(|etcd_server| {
@@ -459,6 +467,14 @@ pub(crate) fn fix_etcd_pod_yaml_hostname(pod_yaml: &str, original_hostname: &str
 pub(crate) fn fix_etcd_pod_yaml_ip(pod_yaml: &str, original_ip: &str, ip: &str) -> Result<String> {
     let mut pod_yaml = pod_yaml.to_string();
 
+    let original_ip = if original_ip.contains(':') {
+        format!("[{original_ip}]")
+    } else {
+        original_ip.to_string()
+    };
+
+    let ip = if ip.contains(':') { format!("[{ip}]") } else { ip.to_string() };
+
     let patterns = [
         (r#"value: "https://{original_ip}:2379""#, r#"value: "https://{ip}:2379""#),
         (r#"value: "{original_ip}""#, r#"value: "{ip}""#),
@@ -466,7 +482,10 @@ pub(crate) fn fix_etcd_pod_yaml_ip(pod_yaml: &str, original_ip: &str, ip: &str) 
 
     for (pattern, replacement) in patterns {
         pod_yaml = pod_yaml
-            .replace(&pattern.replace("{original_ip}", original_ip), &replacement.replace("{ip}", ip))
+            .replace(
+                &pattern.replace("{original_ip}", original_ip.as_str()),
+                &replacement.replace("{ip}", ip.as_str()),
+            )
             .to_string();
     }
 


### PR DESCRIPTION
This PR fixes the IP replacement when an IPv6 is provided or getting replaced. IPv6 IPs should be enclosed in `[ ] ` when used in URLs, but OpenShift in some cases uses brackets for IPv6 IPs also when found in non-URL fields. For example, in the env vars of the etcd container of the `etcd-pod` manifest:

```YAML
- name: "NODE_sno_test_redhat_com_IP"
  value: "[2710:20:0:18::8]"
```

This change ensures that we respect the format of the fields in OCP containing IPv6 IPs (with or without `[ ]`). It also ensures that we support the following cases properly when replacing the  IP:

- seed IPv4 -> recipient IPv4
- seed IPv4 -> recipient IPv6
- seed IPv6 -> recipient IPv4
- seed IPv6 -> recipient IPv6