### PR TITLE
Tuck some fields into structs

### DIFF
--- a/src/cluster_crypto/cert_key_pair.rs
+++ b/src/cluster_crypto/cert_key_pair.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     cluster_crypto::locations::LocationValueType,
-    config::Customizations,
+    config::CryptoCustomizations,
     file_utils::{add_recert_edited_annotation, commit_file, get_filesystem_yaml, recreate_yaml_at_location_with_new_pem},
     k8s_etcd::{get_etcd_json, InMemoryK8sEtcd},
     rsa_key_pool::RsaKeyPool,
@@ -61,11 +61,11 @@ impl CertKeyPair {
         &mut self,
         sign_with: Option<&SigningKey>,
         rsa_key_pool: &mut RsaKeyPool,
-        customizations: &Customizations,
+        crypto_customizations: &CryptoCustomizations,
         skid_edits: &mut SkidEdits,
         serial_number_edits: &mut SerialNumberEdits,
     ) -> Result<()> {
-        let alternative_certificate = customizations
+        let alternative_certificate = crypto_customizations
             .use_cert_rules
             .get_replacement_cert((*self.distributed_cert).borrow_mut().certificate.cert.subject_name())
             .context("evaluating replacement cert")?;
@@ -75,7 +75,7 @@ impl CertKeyPair {
             // so simply regenerate the cert and all of its children
             None => {
                 let (new_cert_subject_signing_key, new_cert) =
-                    self.re_sign_cert(sign_with, rsa_key_pool, customizations, skid_edits, serial_number_edits)?;
+                    self.re_sign_cert(sign_with, rsa_key_pool, crypto_customizations, skid_edits, serial_number_edits)?;
                 let new_cert = Certificate::try_from(&new_cert)?;
                 (*self.distributed_cert).borrow_mut().certificate_regenerated = Some(new_cert.clone());
 
@@ -83,7 +83,7 @@ impl CertKeyPair {
                     signee.regenerate(
                         Some(&new_cert_subject_signing_key),
                         rsa_key_pool,
-                        customizations,
+                        crypto_customizations,
                         Some(skid_edits),
                         Some(serial_number_edits),
                     )?;
@@ -137,7 +137,7 @@ impl CertKeyPair {
         &mut self,
         sign_with: Option<&SigningKey>,
         rsa_key_pool: &mut RsaKeyPool,
-        customizations: &Customizations,
+        crypto_customizations: &CryptoCustomizations,
         skid_edits: &mut SkidEdits,
         serial_number_edits: &mut SerialNumberEdits,
     ) -> Result<(SigningKey, CapturedX509Certificate)> {
@@ -162,7 +162,7 @@ impl CertKeyPair {
         // mkoid 1.2.840.10045.2.1
         let ec_public_key_oid: Oid<Bytes> = Oid(Bytes::from_static(&[42, 134, 72, 206, 61, 2, 1]));
 
-        let self_new_key_pair = if let Some(use_key_rule) = customizations
+        let self_new_key_pair = if let Some(use_key_rule) = crypto_customizations
             .use_key_rules
             .key_file(tbs_certificate.subject.clone())
             .context("getting use key file for cert")?
@@ -256,9 +256,9 @@ impl CertKeyPair {
         // Perform all requested mutations on the certificate
         cert_mutations::mutate_cert(
             &mut tbs_certificate,
-            &customizations.cn_san_replace_rules,
-            customizations.extend_expiration,
-            customizations.force_expire,
+            &crypto_customizations.cn_san_replace_rules,
+            crypto_customizations.extend_expiration,
+            crypto_customizations.force_expire,
         )
         .context("mutating cert")?;
 

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -7,7 +7,7 @@ use super::{
     signee::Signee,
 };
 use crate::{
-    config::Customizations,
+    config::CryptoCustomizations,
     file_utils::{
         add_recert_edited_annotation, commit_file, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem,
     },
@@ -30,7 +30,7 @@ pub(crate) struct DistributedPrivateKey {
 }
 
 impl DistributedPrivateKey {
-    pub(crate) fn regenerate(&mut self, rsa_key_pool: &mut RsaKeyPool, customizations: &Customizations) -> Result<()> {
+    pub(crate) fn regenerate(&mut self, rsa_key_pool: &mut RsaKeyPool, crypto_customizations: &CryptoCustomizations) -> Result<()> {
         let num_bits = match &self.key {
             PrivateKey::Rsa(key) => key.n().to_radix_le(2).len(),
             PrivateKey::Ec(_) => bail!("cannot regenerate standalone EC key"),
@@ -39,7 +39,7 @@ impl DistributedPrivateKey {
         let self_new_key_pair = rsa_key_pool.get(num_bits).context("RSA pool empty")?;
 
         for signee in &mut self.signees {
-            signee.regenerate(Some(&self_new_key_pair), rsa_key_pool, customizations, None, None)?;
+            signee.regenerate(Some(&self_new_key_pair), rsa_key_pool, crypto_customizations, None, None)?;
         }
 
         let regenerated_private_key: PrivateKey = (&self_new_key_pair.in_memory_signing_key_pair).try_into()?;

--- a/src/cluster_crypto/scanning.rs
+++ b/src/cluster_crypto/scanning.rs
@@ -8,7 +8,7 @@ use crate::{
     config::ConfigPath,
     file_utils::{self, read_file_to_string},
     k8s_etcd::{get_etcd_json, InMemoryK8sEtcd},
-    recert::RunTime,
+    recert::timing::RunTime,
 };
 use anyhow::{bail, ensure, Context, Error, Result};
 use futures_util::future::join_all;

--- a/src/cluster_crypto/signee.rs
+++ b/src/cluster_crypto/signee.rs
@@ -1,4 +1,4 @@
-use crate::{config::Customizations, rsa_key_pool::RsaKeyPool};
+use crate::{config::CryptoCustomizations, rsa_key_pool::RsaKeyPool};
 
 use super::{
     cert_key_pair::{CertKeyPair, SerialNumberEdits, SkidEdits},
@@ -32,7 +32,7 @@ impl Signee {
         &mut self,
         new_signing_key: Option<&SigningKey>,
         rsa_key_pool: &mut RsaKeyPool,
-        customizations: &Customizations,
+        crypto_customizations: &CryptoCustomizations,
         skid_edits: Option<&mut SkidEdits>,
         serial_number_edits: Option<&mut SerialNumberEdits>,
     ) -> Result<()> {
@@ -41,7 +41,7 @@ impl Signee {
                 (**cert_key_pair).borrow_mut().regenerate(
                     new_signing_key,
                     rsa_key_pool,
-                    customizations,
+                    crypto_customizations,
                     skid_edits.context("cert regeneration requires skid edits")?,
                     serial_number_edits.context("cert regeneration requires serial number edits")?,
                 )?;

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cnsanreplace::CnSanReplace, ocp_postprocess::cluster_domain_rename::params::ClusterRenameParameters, use_cert::UseCert, use_key::UseKey,
+    cnsanreplace::CnSanReplace, ocp_postprocess::cluster_domain_rename::params::ClusterNamesRename, use_cert::UseCert, use_key::UseKey,
 };
 use clap::Parser;
 use clio::ClioPath;
@@ -32,8 +32,8 @@ pub(crate) struct Cli {
     /// cluster resources which refer to a cluster name / cluster base domain (typically through
     /// URLs which they happen to contian) will be modified to use this cluster name and base
     /// domain instead.
-    #[clap(long, value_parser = ClusterRenameParameters::cli_parse)]
-    pub(crate) cluster_rename: Option<ClusterRenameParameters>,
+    #[clap(long, value_parser = ClusterNamesRename::cli_parse)]
+    pub(crate) cluster_rename: Option<ClusterNamesRename>,
 
     /// If given, the cluster resources that include the hostname will be modified to use this one
     /// instead.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,7 +1,7 @@
 use crate::{
     cluster_crypto::{ClusterCryptoObjects, REDACT_SECRETS},
     config::RecertConfig,
-    recert::RunTimes,
+    recert::timing::RunTimes,
 };
 use anyhow::{bail, Context, Result};
 use lazy_static::lazy_static;

--- a/src/ocp_postprocess/cluster_domain_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename.rs
@@ -1,4 +1,4 @@
-use self::params::ClusterRenameParameters;
+use self::params::ClusterNamesRename;
 use crate::{cluster_crypto::locations::K8sResourceLocation, config::ConfigPath, k8s_etcd::InMemoryK8sEtcd};
 use anyhow::{Context, Result};
 use std::{path::Path, sync::Arc};
@@ -10,7 +10,7 @@ pub(crate) mod rename_utils;
 
 pub(crate) async fn rename_all(
     etcd_client: &Arc<InMemoryK8sEtcd>,
-    cluster_rename: &ClusterRenameParameters,
+    cluster_rename: &ClusterNamesRename,
     static_dirs: &Vec<ConfigPath>,
     static_files: &Vec<ConfigPath>,
 ) -> Result<(), anyhow::Error> {
@@ -93,7 +93,7 @@ async fn fix_etcd_resources(
     etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_domain: &str,
     generated_infra_id: String,
-    cluster_rename: &ClusterRenameParameters,
+    cluster_rename: &ClusterNamesRename,
 ) -> Result<(), anyhow::Error> {
     etcd_rename::fix_router_certs(
         etcd_client,

--- a/src/ocp_postprocess/cluster_domain_rename/params.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/params.rs
@@ -1,13 +1,13 @@
 use anyhow::{ensure, Result};
 
 #[derive(Clone, serde::Serialize)]
-pub(crate) struct ClusterRenameParameters {
+pub(crate) struct ClusterNamesRename {
     pub(crate) cluster_name: String,
     pub(crate) cluster_base_domain: String,
     pub(crate) infra_id: Option<String>,
 }
 
-impl ClusterRenameParameters {
+impl ClusterNamesRename {
     pub(crate) fn cli_parse(value: &str) -> Result<Self> {
         let parts = value.split(':').collect::<Vec<_>>();
 

--- a/src/recert.rs
+++ b/src/recert.rs
@@ -1,53 +1,50 @@
 use crate::{
     cluster_crypto::{crypto_utils::ensure_openssl_version, scanning, ClusterCryptoObjects},
-    config::{ConfigPath, Customizations, RecertConfig},
+    config::{ClusterCustomizations, ConfigPath, CryptoCustomizations, RecertConfig},
     k8s_etcd::InMemoryK8sEtcd,
-    ocp_postprocess::{cluster_domain_rename::params::ClusterRenameParameters, ocp_postprocess},
+    ocp_postprocess::ocp_postprocess,
     rsa_key_pool, server_ssh_keys,
 };
 use anyhow::{Context, Result};
 use etcd_client::Client as EtcdClient;
 use std::{collections::HashSet, path::Path, sync::Arc};
 
-#[derive(Clone)]
-pub(crate) struct RunTime {
-    start: std::time::Instant,
-    end: std::time::Instant,
-}
+use self::timing::{combine_timings, FinalizeTiming, RecertifyTiming, RunTime, RunTimes};
 
-impl RunTime {
-    pub(crate) fn since_start(start: std::time::Instant) -> Self {
-        Self {
-            start,
-            end: std::time::Instant::now(),
-        }
-    }
-}
+pub(crate) mod timing;
 
-impl serde::Serialize for RunTime {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let duration = self.end - self.start;
-        serializer.serialize_str(&format!("{}.{:03}s", duration.as_secs(), duration.subsec_millis()))
-    }
-}
-
-#[derive(serde::Serialize, Clone)]
-pub(crate) struct RunTimes {
-    scan_run_time: RunTime,
-    rsa_run_time: RunTime,
-    processing_run_time: RunTime,
-    commit_to_etcd_and_disk_run_time: RunTime,
-    ocp_postprocessing_run_time: RunTime,
-    commit_to_actual_etcd_run_time: RunTime,
-}
-
-pub(crate) async fn run(parsed_cli: &RecertConfig, cluster_crypto: &mut ClusterCryptoObjects) -> Result<RunTimes> {
+pub(crate) async fn run(recert_config: &RecertConfig, cluster_crypto: &mut ClusterCryptoObjects) -> Result<RunTimes> {
     ensure_openssl_version().context("checking openssl version compatibility")?;
 
-    let in_memory_etcd_client = Arc::new(InMemoryK8sEtcd::new(match &parsed_cli.etcd_endpoint {
+    let in_memory_etcd_client = get_etcd_endpoint(recert_config).await?;
+
+    let recertify_timing = recertify(
+        cluster_crypto,
+        Arc::clone(&in_memory_etcd_client),
+        recert_config.static_dirs.clone(),
+        recert_config.static_files.clone(),
+        &recert_config.crypto_customizations,
+    )
+    .await
+    .context("scanning and recertification")?;
+
+    let finalize_timing = finalize(
+        Arc::clone(&in_memory_etcd_client),
+        cluster_crypto,
+        &recert_config.cluster_customizations,
+        &recert_config.static_dirs,
+        &recert_config.static_files,
+        recert_config.regenerate_server_ssh_keys.as_deref(),
+        recert_config.dry_run,
+    )
+    .await
+    .context("finalizing")?;
+
+    Ok(combine_timings(recertify_timing, finalize_timing))
+}
+
+async fn get_etcd_endpoint(recert_config: &RecertConfig) -> Result<Arc<InMemoryK8sEtcd>, anyhow::Error> {
+    let in_memory_etcd_client = Arc::new(InMemoryK8sEtcd::new(match &recert_config.etcd_endpoint {
         Some(etcd_endpoint) => Some(
             EtcdClient::connect([etcd_endpoint.as_str()], None)
                 .await
@@ -55,41 +52,7 @@ pub(crate) async fn run(parsed_cli: &RecertConfig, cluster_crypto: &mut ClusterC
         ),
         None => None,
     }));
-
-    let (scan_run_time, rsa_run_time, processing_run_time) = recertify(
-        cluster_crypto,
-        Arc::clone(&in_memory_etcd_client),
-        parsed_cli.static_dirs.clone(),
-        parsed_cli.static_files.clone(),
-        &parsed_cli.customizations,
-    )
-    .await
-    .context("scanning and recertification")?;
-
-    let (commit_to_etcd_and_disk_run_time, ocp_postprocessing_run_time, commit_to_actual_etcd_run_time) = finalize(
-        Arc::clone(&in_memory_etcd_client),
-        cluster_crypto,
-        &parsed_cli.cluster_rename,
-        &parsed_cli.hostname,
-        &parsed_cli.ip,
-        &parsed_cli.kubeadmin_password_hash,
-        &parsed_cli.pull_secret,
-        &parsed_cli.static_dirs,
-        &parsed_cli.static_files,
-        parsed_cli.regenerate_server_ssh_keys.as_deref(),
-        parsed_cli.dry_run,
-    )
-    .await
-    .context("finalizing")?;
-
-    Ok(RunTimes {
-        scan_run_time,
-        rsa_run_time,
-        processing_run_time,
-        commit_to_etcd_and_disk_run_time,
-        ocp_postprocessing_run_time,
-        commit_to_actual_etcd_run_time,
-    })
+    Ok(in_memory_etcd_client)
 }
 
 async fn recertify(
@@ -97,8 +60,8 @@ async fn recertify(
     in_memory_etcd_client: Arc<InMemoryK8sEtcd>,
     static_dirs: Vec<ConfigPath>,
     static_files: Vec<ConfigPath>,
-    customizations: &Customizations,
-) -> Result<(RunTime, RunTime, RunTime)> {
+    crypto_customizations: &CryptoCustomizations,
+) -> Result<RecertifyTiming> {
     let external_certs = if in_memory_etcd_client.etcd_client.is_some() {
         scanning::discover_external_certs(Arc::clone(&in_memory_etcd_client))
             .await
@@ -124,11 +87,15 @@ async fn recertify(
     // We discovered all crypto objects, process them
     let start = std::time::Instant::now();
     cluster_crypto
-        .process_objects(all_discovered_crypto_objects, customizations, rsa_pool)
+        .process_objects(all_discovered_crypto_objects, crypto_customizations, rsa_pool)
         .context("processing discovered objects")?;
     let processing_run_time = RunTime::since_start(start);
 
-    Ok((scan_run_time, rsa_run_time, processing_run_time))
+    Ok(RecertifyTiming {
+        scan_run_time,
+        rsa_run_time,
+        processing_run_time,
+    })
 }
 
 async fn fill_keys() -> Result<(RunTime, rsa_key_pool::RsaKeyPool)> {
@@ -137,20 +104,15 @@ async fn fill_keys() -> Result<(RunTime, rsa_key_pool::RsaKeyPool)> {
     Ok((RunTime::since_start(start_time), pool))
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn finalize(
     in_memory_etcd_client: Arc<InMemoryK8sEtcd>,
     cluster_crypto: &mut ClusterCryptoObjects,
-    cluster_rename: &Option<ClusterRenameParameters>,
-    hostname: &Option<String>,
-    ip: &Option<String>,
-    kubeadmin_password_hash: &Option<String>,
-    pull_secret: &Option<String>,
+    cluster_customizations: &ClusterCustomizations,
     static_dirs: &Vec<ConfigPath>,
     static_files: &Vec<ConfigPath>,
     regenerate_server_ssh_keys: Option<&Path>,
     dry_run: bool,
-) -> Result<(RunTime, RunTime, RunTime)> {
+) -> Result<FinalizeTiming> {
     let start = std::time::Instant::now();
     cluster_crypto
         .commit_to_etcd_and_disk(&in_memory_etcd_client)
@@ -160,18 +122,9 @@ async fn finalize(
 
     let start = std::time::Instant::now();
     if in_memory_etcd_client.etcd_client.is_some() {
-        ocp_postprocess(
-            &in_memory_etcd_client,
-            cluster_rename,
-            hostname,
-            ip,
-            kubeadmin_password_hash,
-            pull_secret,
-            static_dirs,
-            static_files,
-        )
-        .await
-        .context("performing ocp specific post-processing")?;
+        ocp_postprocess(&in_memory_etcd_client, cluster_customizations, static_dirs, static_files)
+            .await
+            .context("performing ocp specific post-processing")?;
     }
     let ocp_postprocessing_run_time = RunTime::since_start(start);
 
@@ -196,9 +149,9 @@ async fn finalize(
 
     let commit_to_actual_etcd_run_time = RunTime::since_start(start);
 
-    Ok((
+    Ok(FinalizeTiming {
         commit_to_etcd_and_disk_run_time,
         ocp_postprocessing_run_time,
         commit_to_actual_etcd_run_time,
-    ))
+    })
 }

--- a/src/recert/timing.rs
+++ b/src/recert/timing.rs
@@ -1,0 +1,57 @@
+#[derive(Clone)]
+pub(crate) struct RunTime {
+    start: std::time::Instant,
+    end: std::time::Instant,
+}
+
+impl RunTime {
+    pub(crate) fn since_start(start: std::time::Instant) -> Self {
+        Self {
+            start,
+            end: std::time::Instant::now(),
+        }
+    }
+}
+
+impl serde::Serialize for RunTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let duration = self.end - self.start;
+        serializer.serialize_str(&format!("{}.{:03}s", duration.as_secs(), duration.subsec_millis()))
+    }
+}
+
+#[derive(serde::Serialize, Clone)]
+pub(crate) struct RunTimes {
+    pub(crate) scan_run_time: RunTime,
+    pub(crate) rsa_run_time: RunTime,
+    pub(crate) processing_run_time: RunTime,
+    pub(crate) commit_to_etcd_and_disk_run_time: RunTime,
+    pub(crate) ocp_postprocessing_run_time: RunTime,
+    pub(crate) commit_to_actual_etcd_run_time: RunTime,
+}
+
+pub(crate) struct RecertifyTiming {
+    pub(crate) scan_run_time: RunTime,
+    pub(crate) rsa_run_time: RunTime,
+    pub(crate) processing_run_time: RunTime,
+}
+
+pub(crate) struct FinalizeTiming {
+    pub(crate) commit_to_etcd_and_disk_run_time: RunTime,
+    pub(crate) ocp_postprocessing_run_time: RunTime,
+    pub(crate) commit_to_actual_etcd_run_time: RunTime,
+}
+
+pub(crate) fn combine_timings(recertify_timing: RecertifyTiming, finalize_timing: FinalizeTiming) -> RunTimes {
+    RunTimes {
+        scan_run_time: recertify_timing.scan_run_time,
+        rsa_run_time: recertify_timing.rsa_run_time,
+        processing_run_time: recertify_timing.processing_run_time,
+        commit_to_etcd_and_disk_run_time: finalize_timing.commit_to_etcd_and_disk_run_time,
+        ocp_postprocessing_run_time: finalize_timing.ocp_postprocessing_run_time,
+        commit_to_actual_etcd_run_time: finalize_timing.commit_to_actual_etcd_run_time,
+    }
+}


### PR DESCRIPTION
A recent addition of a lot of rename functionality made the code a bit
unreadable.

This commit tucks all rename-related fields into a struct called
`ClusterCustomizations` so passing them around is more neat.

Did the same for timings related code, and put it in a module, so it's
more out of sight from the main code flow.