### PR TITLE
Don't modify proxy on non-JSON YAML files

### DIFF
--- a/src/ocp_postprocess/proxy_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/proxy_rename/filesystem_rename.rs
@@ -3,7 +3,7 @@ use super::{
     utils::{self, fix_containers, fix_machineconfig},
 };
 use crate::file_utils::{self, commit_file, read_file_to_string};
-use anyhow::{self, Context, Result};
+use anyhow::{self, ensure, Context, Result};
 use futures_util::future::join_all;
 use serde_json::Value;
 use std::{collections::HashSet, path::Path};
@@ -106,13 +106,26 @@ pub(crate) async fn fix_pods_yaml(proxy: &Proxy, dir: &Path) -> Result<()> {
             async move {
                 let contents = read_file_to_string(&file_path).await.context("reading pods.yaml")?;
 
-                let mut config: Value = serde_yaml::from_str(&contents).context("parsing pods.yaml")?;
+                let parsed_as_json = serde_json::from_str(&contents);
 
-                fix_containers(&mut config, &proxy, "/spec").context("fixing containers")?;
+                let pod = match parsed_as_json {
+                    Ok(mut value) => {
+                        fix_containers(&mut value, &proxy, "/spec").context("fixing containers")?;
+                        serde_json::to_string(&value).context("serializing pods.yaml")?
+                    }
+                    Err(_) => {
+                        // We will reach here when the file is non-JSON YAML. For now, none of the
+                        // such files have PROXY env vars so we can skip them. We don't want to
+                        // parse them and then re-serialize them as that could cause formatting
+                        // changes which could lead to rollouts.
+                        ensure!(!contents.contains("HTTP_PROXY"), "HTTP_PROXY env var found in non-JSON YAML file");
+                        ensure!(!contents.contains("HTTPS_PROXY"), "HTTPS_PROXY env var found in non-JSON YAML file");
+                        ensure!(!contents.contains("NO_PROXY"), "NO_PROXY env var found in non-JSON YAML file");
+                        return anyhow::Ok(());
+                    }
+                };
 
-                commit_file(file_path, serde_yaml::to_string(&config).context("serializing pods.yaml")?)
-                    .await
-                    .context("writing pods.yaml to disk")?;
+                commit_file(file_path, pod).await.context("writing pods.yaml to disk")?;
 
                 anyhow::Ok(())
             }

--- a/src/ocp_postprocess/proxy_rename/utils.rs
+++ b/src/ocp_postprocess/proxy_rename/utils.rs
@@ -170,8 +170,8 @@ pub(crate) fn fix_containers(config: &mut Value, proxy: &Proxy, prefix: &str) ->
     Ok(())
 }
 
-// Remove all existing proxy env vars from the container's env and return the index of where
-// the first proxy env var should be inserted. Also removes the order in which the proxy env vars
+// Remove all existing proxy env vars from the container's env and return the index of where the
+// first proxy env var should be inserted. Also removes the order in which the proxy env vars
 // appeared in the original env.
 fn remove_existing_proxy_env_vars(container_env: &mut Vec<Value>, is_upper: bool) -> Result<Option<(usize, Vec<String>)>> {
     let original_proxy_envs = container_env


### PR DESCRIPTION
None of such files have PROXY env vars so we can skip them. We don't
want to parse them and then re-serialize them as that could cause
formatting changes which could lead to rollouts.