### PR TITLE
MGMT-17319: Fix etcd secrets annotations for OCP >4.16

### DIFF
--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -76,14 +76,14 @@ async fn run_cluster_customizations(
             .context("renaming cluster")?;
     }
 
+    if let Some(ip) = &cluster_customizations.ip {
+        ip_rename(in_memory_etcd_client, ip, dirs, files).await.context("renaming IP")?;
+    }
+
     if let Some(hostname) = &cluster_customizations.hostname {
         hostname_rename(in_memory_etcd_client, hostname, dirs, files)
             .await
             .context("renaming hostname")?;
-    }
-
-    if let Some(ip) = &cluster_customizations.ip {
-        ip_rename(in_memory_etcd_client, ip, dirs, files).await.context("renaming IP")?;
     }
 
     if let Some(kubeadmin_password_hash) = &cluster_customizations.kubeadmin_password_hash {

--- a/src/ocp_postprocess/hostname_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/hostname_rename/etcd_rename.rs
@@ -209,6 +209,15 @@ pub(crate) async fn fix_etcd_secrets(etcd_client: &Arc<InMemoryK8sEtcd>, origina
                         .context("/metadata not an object")?
                         .insert("name".to_string(), serde_json::Value::String(new_secret_name.clone()));
 
+                    if let Some(description_annotation) = etcd_value.pointer_mut("/metadata/annotations/openshift.io~1description") {
+                        *description_annotation = Value::String(
+                            description_annotation
+                                .as_str()
+                                .context("openshift.io/description annotation not a string")?
+                                .replace(original_hostname, hostname),
+                        );
+                    }
+
                     etcd_client
                         .put(
                             &(format!("/kubernetes.io/secrets/openshift-etcd/{new_secret_name}")),

--- a/src/ocp_postprocess/ip_rename.rs
+++ b/src/ocp_postprocess/ip_rename.rs
@@ -66,6 +66,10 @@ async fn fix_etcd_resources(etcd_client: &Arc<InMemoryK8sEtcd>, ip: &str) -> Res
         .await
         .context("fixing etcd-scripts")?;
 
+    etcd_rename::fix_etcd_secrets(etcd_client, &original_ip, ip)
+        .await
+        .context("fixing etcd secrets")?;
+
     etcd_rename::fix_kube_apiserver_configs(etcd_client, &original_ip, ip)
         .await
         .context("fixing kube apiserver configs")?;


### PR DESCRIPTION
In OCP 4.16 the cluster-etcd-operator moved to using [library-go/certrotation](https://github.com/openshift/library-go/tree/master/pkg/operator/certrotation) and that leads to the following etcd TLS secrets having annotations that include the IP and the hostname:

- `openshift-etcd/etcd-peer-<hostname>`
- `openshift-etcd/etcd-serving-<hostname>`
- `openshift-etcd/etcd-serving-metrics-<hostname>`

The respective annotations are:
- `auth.openshift.io/certificate-hostnames` - this includes the IP
- `openshift.io/description` - this includes the hostname

Recert now replaces the IP and the hostname in those annotations, in order to skip an additional etcd rollout that is triggered because of the former.

Resources:
- https://github.com/openshift/cluster-etcd-operator/pull/1194
- https://github.com/openshift/library-go/blob/f840ed4b8db36652d101604930ac32df568e583d/pkg/operator/certrotation/target.go#L311
- https://github.com/openshift/cluster-etcd-operator/blob/eeef8033eb058b0f9899c7b16aead237d5b84462/pkg/tlshelpers/tlshelpers.go#L237-L240
    - https://github.com/openshift/library-go/blob/f840ed4b8db36652d101604930ac32df568e583d/pkg/operator/certrotation/annotations.go#L31-L34  
    - https://github.com/openshift/api/blob/master/annotations/annotations.go#L24