### PR TITLE
Include error in recert summary

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -82,12 +82,14 @@ struct Summary {
     recert_config: RecertConfig,
     logs: Vec<String>,
     run_times: Option<RunTimes>,
+    error: Option<String>,
 }
 
 pub(crate) fn generate_summary(
     recert_config: RecertConfig,
     cluster_crypto: ClusterCryptoObjects,
     run_result: Option<RunTimes>,
+    error: Option<&anyhow::Error>,
 ) -> Result<()> {
     let logs = match LOG_RECORDS.lock() {
         Ok(logs) => logs.clone(),
@@ -101,6 +103,7 @@ pub(crate) fn generate_summary(
         recert_config,
         logs,
         run_times: run_result,
+        error: error.map(|e| format!("{:?}", e)),
     };
 
     if let Some(summary_file) = summary.recert_config.summary_file.clone() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,12 @@ async fn main_internal(config: RecertConfig) -> Result<()> {
 
     let run_result = recert::run(&config, &mut cluster_crypto).await;
 
-    let run_times = match &run_result {
-        Ok(run_times) => Some(run_times.clone()),
-        Err(_) => None,
+    let (maybe_error, run_times) = match &run_result {
+        Ok(run_times) => (None, Some(run_times.clone())),
+        Err(err) => (Some(err), None),
     };
 
-    logging::generate_summary(config, cluster_crypto, run_times)?;
+    logging::generate_summary(config, cluster_crypto, run_times, maybe_error)?;
 
     if let Err(err) = run_result {
         Err(err)


### PR DESCRIPTION
When recert runs into an error, it returns it as a `Result` from the
`main` function. This causes the Rust runtime to print the error trace.

However, the error does not get included in the recert summary files. In
the summary, you only see the logs, which makes it look like no error
occurred.

This commit makes it so that when recert runs into an error the error
will be included in summary files