### PR TITLE
OCPBUGS-33471: Fix proxy ordering

### DIFF
--- a/src/ocp_postprocess/proxy_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/proxy_rename/etcd_rename.rs
@@ -268,8 +268,8 @@ pub(crate) async fn fix_storages(etcd_client: &InMemoryK8sEtcd, proxy: &Proxy) -
 }
 
 fn generic_proxy_fix(spec: &mut serde_json::Map<String, Value>, proxy: &Proxy) {
-    spec.insert("HTTPS_PROXY".to_string(), Value::String(proxy.status_proxy.http_proxy.clone()));
-    spec.insert("HTTP_PROXY".to_string(), Value::String(proxy.status_proxy.https_proxy.clone()));
+    spec.insert("HTTP_PROXY".to_string(), Value::String(proxy.status_proxy.http_proxy.clone()));
+    spec.insert("HTTPS_PROXY".to_string(), Value::String(proxy.status_proxy.https_proxy.clone()));
     spec.insert("NO_PROXY".to_string(), Value::String(proxy.status_proxy.no_proxy.clone()));
 }
 


### PR DESCRIPTION
# Background / Context

recert recently added a `--proxy` feature that replaces the proxy configuration in the cluster

# Issue / Requirement / Reason for change

The `--proxy` feature is not working as expected, some rollouts happen due to the order of the proxy env vars in the kube-apiserver's and kube-controller-manager's container's env. Seems to happen a few times before the cluster stabilizes

This is simply because of a typo in the code, the `HTTP_PROXY` and `HTTPS_PROXY` env vars are being swapped in the `generic_proxy_fix` function

Solves OCPBUGS-33471

# Solution / Feature Overview

Fix the typo in the `generic_proxy_fix` function

# Other Information

The back-and-forth rollouts in e.g. kube-apiserver are due to the `KubeAPIServer` CR being at first in correct, which causes the deployment of the `kube-apiserver` to change, then another controller reads the fixes the `KubeAPIServer` CR itself, which then causes yet another revision

Also made some changes to the tests, even though those changes would not have caught this bug.