### PR TITLE
OCPBUGS-32553: post-pivot does not restore ntp servers

### DIFF
--- a/hack/dummy_config.yaml
+++ b/hack/dummy_config.yaml
@@ -14,6 +14,7 @@ cluster_customization_dirs:
 cluster_customization_files:
 - backup/etc/mcs-machine-config-content.json
 - backup/etc/mco/proxy.env
+- backup/etc/chrony.conf
 cn_san_replace_rules:
 - api-int.seed.redhat.com:api-int.new-name.foo.com
 - api.seed.redhat.com:api.new-name.foo.com
@@ -129,6 +130,11 @@ additional_trust_bundle: |
     42TI0UzcqRV4CWDoARMSV8yMLajZ0g1eEreUprwmFcOy17V7KCeV6E8lKb21OU8M
     Ad9q3H0iXjct
     -----END CERTIFICATE-----
+chrony_config: |
+    pool 0.rhel.pool.ntp.org iburst
+    driftfile /var/lib/chrony/drift
+    server test iburst
+    
 summary_file: summary.yaml
 summary_file_clean: summary_redacted.yaml
 extend_expiration: true

--- a/run_seed.sh
+++ b/run_seed.sh
@@ -77,6 +77,7 @@ else
 		--crypto-dir backup/var/lib/kubelet \
 		--crypto-dir backup/etc/machine-config-daemon \
 		--crypto-file backup/etc/mcs-machine-config-content.json \
+		--cluster-customization-file backup/etc/chrony.conf \
         \
 		--cluster-customization-dir backup/etc/kubernetes \
 		--cluster-customization-dir backup/var/lib/kubelet \
@@ -134,6 +135,10 @@ sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDThIOETj6iTvbCaNv15tZg121nWLcwtJuZ
 		--kubeadmin-password-hash '$2a$10$20Q4iRLy7cWZkjn/D07bF.RZQZonKwstyRGH0qiYbYRkx5Pe4Ztyi' \
 		--additional-trust-bundle ./hack/dummy_trust_bundle.pem \
 		--pull-secret '{"auths":{"empty_registry":{"username":"empty","password":"empty","auth":"ZW1wdHk6ZW1wdHk=","email":""}}}' \
+		--chrony-config 'pool 0.rhel.pool.ntp.org iburst
+driftfile /var/lib/chrony/drift
+server test iburst
+' \
         \
 		--summary-file summary.yaml \
 		--summary-file-clean summary_redacted.yaml \

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub(crate) struct ClusterCustomizations {
     pub(crate) pull_secret: Option<String>,
     pub(crate) additional_trust_bundle: Option<String>,
     pub(crate) machine_network_cidr: Option<String>,
+    pub(crate) chrony_config: Option<String>,
 }
 
 /// All parsed CLI arguments, coalesced into a single struct for convenience
@@ -144,6 +145,7 @@ impl RecertConfig {
                 proxy: None,
                 install_config: None,
                 machine_network_cidr: None,
+                chrony_config: None,
             },
             threads: None,
             regenerate_server_ssh_keys: None,
@@ -229,6 +231,11 @@ impl RecertConfig {
             Some(value) => Some(value.as_str().context("machine_network_cidr must be a string")?.to_string()),
             None => None,
         };
+        let chrony_config = match value.remove("chrony_config") {
+            Some(value) => Some(value.as_str().context("chrony_config must be a string")?.to_string()),
+            None => None,
+        };
+
         let dry_run = value
             .remove("dry_run")
             .unwrap_or(Value::Bool(false))
@@ -283,6 +290,7 @@ impl RecertConfig {
             proxy,
             install_config,
             machine_network_cidr,
+            chrony_config,
         };
 
         let recert_config = Self {
@@ -358,6 +366,7 @@ impl RecertConfig {
                 pull_secret: cli.pull_secret,
                 additional_trust_bundle: cli.additional_trust_bundle,
                 machine_network_cidr: cli.machine_network_cidr,
+                chrony_config: cli.chrony_config,
             },
             threads: cli.threads,
             regenerate_server_ssh_keys: cli.regenerate_server_ssh_keys.map(ConfigPath::from),

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -113,6 +113,10 @@ pub(crate) struct Cli {
     #[clap(long)]
     pub(crate) machine_network_cidr: Option<String>,
 
+    /// If given, the cluster resources that include chrony.config be modified to have this value.
+    #[clap(long)]
+    pub(crate) chrony_config: Option<String>,
+
     /// A list of CNs and the private keys to use for their certs. By default, new keys will be
     /// generated for all regenerated certificates, this option allows you to use existing keys
     /// instead. Must come in pairs of CN and private key file path, separated by a space. For

--- a/src/ocp_postprocess/chrony_config.rs
+++ b/src/ocp_postprocess/chrony_config.rs
@@ -1,0 +1,66 @@
+use crate::{config::path::ConfigPath, k8s_etcd::InMemoryK8sEtcd};
+
+use anyhow::{Context, Result};
+use std::{path::Path, sync::Arc};
+
+mod etcd_rename;
+mod filesystem_rename;
+mod utils;
+
+const CHRONY_PATH: &str = "/etc/chrony.conf";
+
+pub(crate) async fn rename_all(
+    etcd_client: &Arc<InMemoryK8sEtcd>,
+    chrony_content: &str,
+    static_dirs: &[ConfigPath],
+    static_files: &[ConfigPath],
+) -> Result<()> {
+    fix_etcd_resources(etcd_client, chrony_content)
+        .await
+        .context("overriding etcd resources")?;
+
+    fix_filesystem_resources(chrony_content, static_dirs, static_files)
+        .await
+        .context("overriding filesystem resources")?;
+
+    Ok(())
+}
+
+async fn fix_filesystem_resources(chrony_content: &str, static_dirs: &[ConfigPath], static_files: &[ConfigPath]) -> Result<()> {
+    for dir in static_dirs {
+        fix_dir_resources(chrony_content, dir).await?;
+    }
+    for file in static_files {
+        fix_file_resources(chrony_content, file).await?;
+    }
+
+    Ok(())
+}
+
+async fn fix_dir_resources(chrony_config: &str, dir: &Path) -> Result<()> {
+    utils::fix_filesystem_currentconfig(chrony_config, CHRONY_PATH, dir)
+        .await
+        .context("renaming currentconfig")?;
+
+    Ok(())
+}
+
+async fn fix_file_resources(chrony_content: &str, file: &Path) -> Result<()> {
+    filesystem_rename::fix_filesystem_mcs_machine_config_content(chrony_content, CHRONY_PATH, file)
+        .await
+        .context("fix filesystem mcs machine config content")?;
+
+    filesystem_rename::fix_filesystem_chrony_config(chrony_content, file)
+        .await
+        .context("fix filesystem chrony config")?;
+
+    Ok(())
+}
+
+async fn fix_etcd_resources(etcd_client: &Arc<InMemoryK8sEtcd>, chrony_content: &str) -> Result<()> {
+    etcd_rename::fix_machineconfigs(etcd_client, chrony_content, CHRONY_PATH)
+        .await
+        .context("fixing chrony.conf in machine configs")?;
+
+    Ok(())
+}

--- a/src/ocp_postprocess/chrony_config/etcd_rename.rs
+++ b/src/ocp_postprocess/chrony_config/etcd_rename.rs
@@ -1,0 +1,10 @@
+use crate::{k8s_etcd::InMemoryK8sEtcd, ocp_postprocess::rename_utils};
+use anyhow::{Context, Result};
+use std::sync::Arc;
+
+pub(crate) async fn fix_machineconfigs(etcd_client: &Arc<InMemoryK8sEtcd>, chrony_content: &str, chrony_content_path: &str) -> Result<()> {
+    rename_utils::fix_etcd_machineconfigs(etcd_client, chrony_content, chrony_content_path)
+        .await
+        .context("fixing chrony config content in machine configs")?;
+    Ok(())
+}

--- a/src/ocp_postprocess/chrony_config/filesystem_rename.rs
+++ b/src/ocp_postprocess/chrony_config/filesystem_rename.rs
@@ -1,0 +1,29 @@
+use crate::{file_utils::commit_file, ocp_postprocess::rename_utils};
+use anyhow::{self, Context, Result};
+use std::path::Path;
+
+pub(crate) async fn fix_filesystem_chrony_config(chrony_config: &str, file_path: &Path) -> Result<()> {
+    if let Some(file_name) = file_path.file_name() {
+        if let Some(file_name) = file_name.to_str() {
+            if file_name == "chrony.conf" {
+                let chrony_config = chrony_config.to_string();
+                commit_file(file_path, &chrony_config)
+                    .await
+                    .context("writing chrony.conf to disk")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn fix_filesystem_mcs_machine_config_content(
+    chrony_config: &str,
+    chrony_config_path: &str,
+    file_path: &Path,
+) -> Result<()> {
+    rename_utils::fix_filesystem_mcs_machine_config_content(chrony_config, chrony_config_path, file_path)
+        .await
+        .context("fix filesystem mcs machine config with new chrony config content")?;
+    Ok(())
+}

--- a/src/ocp_postprocess/chrony_config/utils.rs
+++ b/src/ocp_postprocess/chrony_config/utils.rs
@@ -1,0 +1,38 @@
+use crate::file_utils::{self, commit_file, read_file_to_string};
+use crate::ocp_postprocess::rename_utils::override_machineconfig_source;
+use anyhow::{Context, Result};
+use futures_util::future::join_all;
+use serde_json::Value;
+
+use std::path::Path;
+
+pub(crate) async fn fix_filesystem_currentconfig(new_content: &str, file_path_to_change: &str, dir: &Path) -> Result<()> {
+    join_all(file_utils::globvec(dir, "**/currentconfig")?.into_iter().map(|file_path| {
+        let config_path = file_path.clone();
+        let new_content = new_content.to_string();
+        let file_path_to_change = file_path_to_change.to_string();
+        tokio::spawn(async move {
+            async move {
+                let contents = read_file_to_string(&file_path).await.context("reading currentconfig data")?;
+                let mut config: Value = serde_json::from_str(&contents).context("parsing currentconfig")?;
+
+                override_machineconfig_source(&mut config, &new_content, &file_path_to_change)?;
+
+                commit_file(file_path, serde_json::to_string(&config).context("serializing currentconfig")?)
+                    .await
+                    .context("writing currentconfig to disk")?;
+
+                anyhow::Ok(())
+            }
+            .await
+            .context(format!("fixing currentconfig {:?}", config_path))
+        })
+    }))
+    .await
+    .into_iter()
+    .collect::<core::result::Result<Vec<_>, _>>()?
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    Ok(())
+}

--- a/src/ocp_postprocess/cluster_domain_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename.rs
@@ -1,12 +1,13 @@
 use self::params::ClusterNamesRename;
-use crate::{cluster_crypto::locations::K8sResourceLocation, config::path::ConfigPath, k8s_etcd::InMemoryK8sEtcd};
+use crate::{
+    cluster_crypto::locations::K8sResourceLocation, config::path::ConfigPath, k8s_etcd::InMemoryK8sEtcd, ocp_postprocess::rename_utils,
+};
 use anyhow::{Context, Result};
 use std::{path::Path, sync::Arc};
 
 mod etcd_rename;
 mod filesystem_rename;
 pub(crate) mod params;
-pub(crate) mod rename_utils;
 
 pub(crate) async fn rename_all(
     etcd_client: &Arc<InMemoryK8sEtcd>,

--- a/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
@@ -1,9 +1,10 @@
-use super::rename_utils::{
-    self, fix_api_server_arguments_domain, fix_kcm_extended_args, fix_kcm_pod, fix_machineconfig, fix_oauth_metadata, fix_pod_container_env,
-};
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
     k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
+    ocp_postprocess::rename_utils::{
+        fix_api_server_arguments_domain, fix_kcm_extended_args, fix_kcm_pod, fix_machineconfig, fix_mcd_pod_container_args,
+        fix_oauth_metadata, fix_pod_container_env,
+    },
 };
 use anyhow::{bail, ensure, Context, Result};
 use fn_error_context::context;
@@ -1422,7 +1423,7 @@ pub(crate) async fn fix_mcs_daemonset(etcd_client: &InMemoryK8sEtcd, cluster_dom
 
     let pod = &mut daemonset.pointer_mut("/spec/template").context("no /spec/template")?;
 
-    rename_utils::fix_mcd_pod_container_args(pod, cluster_domain, "machine-config-server").context("fixing pod")?;
+    fix_mcd_pod_container_args(pod, cluster_domain, "machine-config-server").context("fixing pod")?;
 
     put_etcd_yaml(etcd_client, &k8s_resource_location, daemonset).await?;
 

--- a/src/ocp_postprocess/hostname_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/hostname_rename/etcd_rename.rs
@@ -1,7 +1,7 @@
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
     k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
-    ocp_postprocess::cluster_domain_rename::rename_utils::{env_var_safe, fix_etcd_pod_yaml_hostname},
+    ocp_postprocess::rename_utils::{env_var_safe, fix_etcd_pod_yaml_hostname},
 };
 use anyhow::{ensure, Context, Result};
 use futures_util::future::join_all;

--- a/src/ocp_postprocess/hostname_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/hostname_rename/filesystem_rename.rs
@@ -1,6 +1,6 @@
 use crate::{
     file_utils::{self, commit_file, read_file_to_string, DRY_RUN},
-    ocp_postprocess::cluster_domain_rename::rename_utils,
+    ocp_postprocess::rename_utils,
 };
 use anyhow::{self, Context, Result};
 use futures_util::future::join_all;

--- a/src/ocp_postprocess/ip_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/ip_rename/etcd_rename.rs
@@ -1,7 +1,7 @@
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
     k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
-    ocp_postprocess::cluster_domain_rename::rename_utils::{fix_api_server_arguments_ip, fix_etcd_pod_yaml_ip},
+    ocp_postprocess::rename_utils::{fix_api_server_arguments_ip, fix_etcd_pod_yaml_ip},
 };
 use anyhow::{bail, ensure, Context, Result};
 use futures_util::future::join_all;

--- a/src/ocp_postprocess/pull_secret_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/pull_secret_rename/etcd_rename.rs
@@ -1,45 +1,15 @@
-use super::utils::override_machineconfig_source;
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
     k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
+    ocp_postprocess::rename_utils,
 };
 use anyhow::{Context, Result};
-use futures_util::future::join_all;
-use serde_json::Value;
 use std::sync::Arc;
 
-pub(crate) async fn fix_machineconfigs(etcd_client: &Arc<InMemoryK8sEtcd>, pull_secret: &str) -> Result<()> {
-    join_all(
-        etcd_client
-            .list_keys("machineconfiguration.openshift.io/machineconfigs")
-            .await?
-            .into_iter()
-            .map(|key| async move {
-                let etcd_result = etcd_client
-                    .get(key.clone())
-                    .await
-                    .with_context(|| format!("getting key {:?}", key))?
-                    .context("key disappeared")?;
-                let value: Value = serde_yaml::from_slice(etcd_result.value.as_slice())
-                    .with_context(|| format!("deserializing value of key {:?}", key,))?;
-                let k8s_resource_location = K8sResourceLocation::try_from(&value)?;
-
-                let mut machineconfig = get_etcd_json(etcd_client, &k8s_resource_location)
-                    .await?
-                    .context("no machineconfig")?;
-
-                override_machineconfig_source(&mut machineconfig, pull_secret, "/var/lib/kubelet/config.json")
-                    .context("fixing machineconfig")?;
-
-                put_etcd_yaml(etcd_client, &k8s_resource_location, machineconfig).await?;
-
-                Ok(())
-            }),
-    )
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?;
-
+pub(crate) async fn fix_machineconfigs(etcd_client: &Arc<InMemoryK8sEtcd>, content: &str) -> Result<()> {
+    rename_utils::fix_etcd_machineconfigs(etcd_client, content, "/var/lib/kubelet/config.json")
+        .await
+        .context("fixing pull secret machine configs")?;
     Ok(())
 }
 

--- a/src/ocp_postprocess/pull_secret_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/pull_secret_rename/filesystem_rename.rs
@@ -1,29 +1,17 @@
 use super::utils::override_machineconfig_source;
-use crate::file_utils::{self, commit_file, read_file_to_string};
+use crate::{
+    file_utils::{self, commit_file, read_file_to_string},
+    ocp_postprocess::rename_utils,
+};
 use anyhow::{self, Context, Result};
 use futures_util::future::join_all;
 use serde_json::Value;
 use std::path::Path;
 
 pub(crate) async fn fix_filesystem_mcs_machine_config_content(pull_secret: &str, file_path: &Path) -> Result<()> {
-    if let Some(file_name) = file_path.file_name() {
-        if let Some(file_name) = file_name.to_str() {
-            if file_name == "mcs-machine-config-content.json" {
-                let contents = read_file_to_string(file_path)
-                    .await
-                    .context("reading machine config currentconfig")?;
-
-                let mut config: Value = serde_json::from_str(&contents).context("parsing currentconfig")?;
-
-                override_machineconfig_source(&mut config, pull_secret, "/var/lib/kubelet/config.json")?;
-
-                commit_file(file_path, serde_json::to_string(&config).context("serializing currentconfig")?)
-                    .await
-                    .context("writing currentconfig to disk")?;
-            }
-        }
-    }
-
+    rename_utils::fix_filesystem_mcs_machine_config_content(pull_secret, "/var/lib/kubelet/config.json", file_path)
+        .await
+        .context("fix filesystem mcs machine config pull secret content")?;
     Ok(())
 }
 


### PR DESCRIPTION
OCPBUGS-32553: post-pivot does not restore ntp servers

As part of cluster creation assisted-service or user creates machine config that changes /etc/chrony.conf file in order to setup ntp servers. We need to allow copying this configuration from target sno to updated cluster.
Current change allows to provide recert with new chrony.conf that will be changed in all machine configs + /etc/chrony.conf. This pr also makes some function generic in order to reuse the logic