### PR TITLE
MGMT-16961: Support replacing the IP on the filesystem

### DIFF
--- a/src/ocp_postprocess/ip_rename.rs
+++ b/src/ocp_postprocess/ip_rename.rs
@@ -27,11 +27,10 @@ async fn fix_filesystem_resources(original_ip: &str, ip: &str, dirs: &[ConfigPat
     Ok(())
 }
 
-async fn fix_dir_resources(_original_ip: &str, _ip: &str, _dir: &Path) -> Result<()> {
-    // TODO: This is currently achieved using:
-    // https://github.com/openshift-kni/lifecycle-agent/blob/3f447f629cf73a25a350c1c2cc88d95bf2a31956/lca-cli/postpivot/postpivot.go#L232-L236
-    //
-    // But it should be done using recert instead at some point.
+async fn fix_dir_resources(original_ip: &str, ip: &str, dir: &Path) -> Result<()> {
+    filesystem_rename::fix_filesystem_ip(original_ip, ip, dir)
+        .await
+        .context(format!("fix filesystem ip in {:?}", dir))?;
     Ok(())
 }
 

--- a/src/ocp_postprocess/ip_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/ip_rename/etcd_rename.rs
@@ -1,7 +1,7 @@
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
     k8s_etcd::{get_etcd_json, put_etcd_yaml, InMemoryK8sEtcd},
-    ocp_postprocess::rename_utils::{fix_api_server_arguments_ip, fix_etcd_pod_yaml_ip},
+    ocp_postprocess::rename_utils::{fix_api_server_arguments_ip, fix_ip},
 };
 use anyhow::{bail, ensure, Context, Result};
 use futures_util::future::join_all;
@@ -209,7 +209,7 @@ pub(crate) async fn fix_etcd_pod(etcd_client: &Arc<InMemoryK8sEtcd>, original_ip
                     .context("pod.yaml not a string")?
                     .to_string();
 
-                let pod_yaml = fix_etcd_pod_yaml_ip(&pod_yaml, original_ip, ip).context("could not fix pod yaml")?;
+                let pod_yaml = fix_ip(&pod_yaml, original_ip, ip).context("could not fix pod yaml")?;
 
                 data.insert("pod.yaml".to_string(), serde_json::Value::String(pod_yaml));
 

--- a/src/ocp_postprocess/ip_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/ip_rename/filesystem_rename.rs
@@ -1,1 +1,52 @@
+use crate::{
+    file_utils::{self, commit_file, read_file_to_string},
+    ocp_postprocess::rename_utils,
+};
+use anyhow::{self, Context, Result};
+use futures_util::future::join_all;
+use std::path::Path;
 
+pub(crate) async fn fix_filesystem_ip(original_ip: &str, ip: &str, dir: &Path) -> Result<()> {
+    join_all(
+        file_utils::globvec(dir, "**/etcd-pod.yaml")?
+            .into_iter()
+            .chain(file_utils::globvec(dir, "**/*etcd-pod/pod.yaml")?)
+            .into_iter()
+            .chain(file_utils::globvec(dir, "**/etcd-scripts/etcd.env")?)
+            .into_iter()
+            .chain(file_utils::globvec(dir, "**/etcd-endpoints/*")?)
+            .into_iter()
+            .chain(file_utils::globvec(dir, "**/kube-apiserver-pod-*/configmaps/config/config.yaml")?)
+            .into_iter()
+            .map(|file_path| {
+                let path = file_path.clone();
+                let original_ip = original_ip.to_string();
+                let ip = ip.to_string();
+                tokio::spawn(async move {
+                    let cloned_path = file_path.clone();
+                    async move {
+                        let contents = read_file_to_string(&file_path)
+                            .await
+                            .context(format!("reading {:?}", cloned_path))?;
+
+                        commit_file(
+                            file_path,
+                            rename_utils::fix_ip(&contents, &original_ip, &ip).context(format!("fixing {:?}", cloned_path))?,
+                        )
+                        .await
+                        .context(format!("writing {:?}", cloned_path))?;
+
+                        anyhow::Ok(())
+                    }
+                    .await
+                    .context(format!("fixing {:?}", path))
+                })
+            }),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>, _>>()?
+    .into_iter()
+    .collect::<Result<Vec<_>, _>>()?;
+    Ok(())
+}

--- a/src/ocp_postprocess/rename_utils.rs
+++ b/src/ocp_postprocess/rename_utils.rs
@@ -471,7 +471,7 @@ pub(crate) fn fix_etcd_pod_yaml_hostname(pod_yaml: &str, original_hostname: &str
     Ok(pod_yaml)
 }
 
-pub(crate) fn fix_etcd_pod_yaml_ip(pod_yaml: &str, original_ip: &str, ip: &str) -> Result<String> {
+pub(crate) fn fix_ip(pod_yaml: &str, original_ip: &str, ip: &str) -> Result<String> {
     let mut pod_yaml = pod_yaml.to_string();
 
     let original_ip = if original_ip.contains(':') {
@@ -481,21 +481,7 @@ pub(crate) fn fix_etcd_pod_yaml_ip(pod_yaml: &str, original_ip: &str, ip: &str) 
     };
 
     let ip = if ip.contains(':') { format!("[{ip}]") } else { ip.to_string() };
-
-    let patterns = [
-        (r#"value: "https://{original_ip}:2379""#, r#"value: "https://{ip}:2379""#),
-        (r#"value: "{original_ip}""#, r#"value: "{ip}""#),
-    ];
-
-    for (pattern, replacement) in patterns {
-        pod_yaml = pod_yaml
-            .replace(
-                &pattern.replace("{original_ip}", original_ip.as_str()),
-                &replacement.replace("{ip}", ip.as_str()),
-            )
-            .to_string();
-    }
-
+    pod_yaml = pod_yaml.replace(original_ip.as_str(), ip.as_str()).to_string();
     Ok(pod_yaml)
 }
 


### PR DESCRIPTION
[MGMT-16961](https://issues.redhat.com//browse/MGMT-16961): Support replacing the IP on the filesystem
Till this PR recert only updated IP in etcd and we relied on LCA to update the filesystem. This code adds logic to update ip in all required files inside /etc/kubernetes. We replace old ip with new one file by file.