### PR TITLE
Sync v0 to latest master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN cargo build --release --bin recert
 FROM docker.io/library/debian:bookworm AS runtime
 WORKDIR app
 RUN apt-get update
-RUN apt-get install -y openssl
+RUN apt-get install -y openssl openssh-client
 COPY --from=builder /app/target/release/recert /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/recert"]


### PR DESCRIPTION
IBI is currently broken because it requires https://github.com/rh-ecosystem-edge/recert/pull/150