### PR TITLE
Setting new ip to etcd member

### DIFF
--- a/src/ocp_postprocess/ip_rename.rs
+++ b/src/ocp_postprocess/ip_rename.rs
@@ -83,5 +83,7 @@ async fn fix_etcd_resources(etcd_client: &Arc<InMemoryK8sEtcd>, ip: &str) -> Res
         .await
         .context("fixing oauth apiserver deployment")?;
 
+    etcd_rename::fix_etcd_member(etcd_client, ip).await.context("fixing etcd member")?;
+
     Ok(original_ip)
 }

--- a/src/ocp_postprocess/ip_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/ip_rename/etcd_rename.rs
@@ -6,6 +6,7 @@ use crate::{
 use anyhow::{bail, ensure, Context, Result};
 use futures_util::future::join_all;
 use serde_json::Value;
+use std::net::Ipv6Addr;
 use std::sync::Arc;
 
 pub(crate) async fn fix_openshift_apiserver_configmap(etcd_client: &Arc<InMemoryK8sEtcd>, ip: &str) -> Result<String> {
@@ -445,6 +446,16 @@ pub(crate) async fn fix_networks_cluster(etcd_client: &Arc<InMemoryK8sEtcd>, ip:
         }
     }
 
+    Ok(())
+}
+
+pub(crate) async fn fix_etcd_member(etcd_client: &Arc<InMemoryK8sEtcd>, ip: &str) -> Result<()> {
+    let mut update = format!("https://{}:2380", ip).to_string();
+    if ip.parse::<Ipv6Addr>().is_ok() {
+        update = format!("https://[{}]:2380", ip).to_string();
+    }
+
+    etcd_client.update_member(update).await.context("failed to update etcd member")?;
     Ok(())
 }
 


### PR DESCRIPTION
This commit implements logic from lca https://github.com/openshift-kni/lifecycle-agent/blob/main/lca-cli/postpivot/postpivot.go#L358

As we moved all the ip change logic into recert we should handle this part here too.

This code updates existing member with new ip 