### PR TITLE
Add temporary approvers for initial konflux setup

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,8 @@ filters:
     - omertuc
     - mresvanis
     - tsorya
+    - fontivan
+    - rauhersu
   ^Dockerfile:
     reviewers:
     - rauhersu


### PR DESCRIPTION
Add Raul and Steven temporarily to the approvers list until Konflux is setup, then we can restrict their approval privileges to specific directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded the team’s review and approval process to enhance quality control across the project.
  - Introduced additional oversight for specialized components to further streamline updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->