### PR TITLE
jwt: calculate kid from public key

### DIFF
--- a/src/cluster_crypto/crypto_utils.rs
+++ b/src/cluster_crypto/crypto_utils.rs
@@ -1,7 +1,11 @@
 use super::certificate;
 use anyhow::ensure;
 use anyhow::{bail, Context, Result};
-use base64::{engine::general_purpose::STANDARD as base64_standard, Engine as _};
+use base64::{
+    engine::general_purpose::{STANDARD as base64_standard, URL_SAFE_NO_PAD as base64_url},
+    Engine as _,
+};
+use bcder::BitString;
 use bcder::{encode::Values, Mode};
 use pkcs1::DecodeRsaPrivateKey;
 use rsa::{self, pkcs8::EncodePrivateKey, RsaPrivateKey};
@@ -11,13 +15,35 @@ use std::path::Path;
 use std::process::Command as StdCommand;
 use std::process::Stdio;
 use tokio::process::Command;
-use x509_certificate::{rfc5280, EcdsaCurve, InMemorySigningKeyPair};
+use x509_certificate::{rfc5280, EcdsaCurve, InMemorySigningKeyPair, KeyAlgorithm, Sign};
 
 pub(crate) mod jwt;
 
 pub(crate) struct SigningKey {
     pub in_memory_signing_key_pair: InMemorySigningKeyPair,
     pkcs8_pem: Vec<u8>,
+}
+
+impl SigningKey {
+    /// Generates the "kid" field for a JWT header in accordance with how Kubernetes does it (a
+    /// Base64URL-encoded SHA256 hash of the PKIX DER encoding of the public key derived from the
+    /// private key)
+    // Implementation based on https://github.com/openshift/kubernetes/blob/6fdacf04117cef54a0babd0945e8ef87d0f9461d/pkg/serviceaccount/jwt.go#L92-L112
+    fn jwt_key_id(&self) -> Result<String> {
+        let keyinfo = rfc5280::SubjectPublicKeyInfo {
+            algorithm: KeyAlgorithm::Rsa.into(),
+            subject_public_key: BitString::new(0, self.in_memory_signing_key_pair.public_key_data()),
+        };
+        let pkix_der_bytes = {
+            let mut buffer: Vec<u8> = Vec::new();
+            keyinfo
+                .encode_ref()
+                .write_encoded(bcder::Mode::Der, &mut buffer)
+                .context("encode")?;
+            buffer
+        };
+        Ok(base64_url.encode(sha256(pkix_der_bytes.as_slice()).context("hash")?))
+    }
 }
 
 impl Clone for SigningKey {
@@ -274,4 +300,102 @@ pub(crate) fn ensure_openssl_version() -> Result<()> {
     log::info!("OpenSSL version is compatible");
 
     Ok(())
+}
+
+mod test {
+    #[test]
+    fn test_kid() {
+        let signing_key = {
+            // I ran this key through the Linux `rev` util to avoid random GitHub security scanners
+            // from screaming at me, it's just a test key, it's not confidential
+            let private_key_obfuscated = "-----YEK ETAVIRP NIGEB-----
+PSBRSYflxWzN8CQABIoAAEgAlSggwkKBCSAAFEQAB0w9GikhqkgBNADABIwvEIIM
+mp/I/mejSYZybQr8ZbV/06xHnSHSJgmkBgWFmZJTm98NeqvVyny24/d3+mo7rXM8
+Mb542VasOhyEwKVO1dhIo46IU2yGE7FE0+JPQodYx5EuZ5OzzXUgjnFmniWFxJWS
+lXNUeZHQ3Y37NhzcHHHeEK7wUPz/6Jp9aHScX5smfzXlw5WHjQgNmCOg4M5Hp7zu
+m5K4N+s00ekY2Yy4WsMWQbzqBqs6KCTaSZ16pCbrt+6ctCYYGUG5J7ayqlA4KQLm
+FvcaEKrI7QDTykqZ3hervkPQ6QvhAc3mx6vBShg+/LvOcOtUMJNc4jvePCr5G8x0
+pWFXKfjdDtpUPbJqO8HuShy6gBZSuYzvUhs/50jgaZGFAEggCEAABMgA5iBb028H
+/SmR6NBD8pyecF4o3CRIVsOMxcBDhiqByLQ5FckTL8d+cYpzI2Z5pcF+uZLJ9RHI
+P6uAxbyb4n2Z3svHQtijwsWXGBwtV5M3xEJ4VnMsf99r4uhpHtEzLnz4ykDrB1Yv
+5fRVG5OnJrGJm5MlINKs7iqCMf2EbpAlvW6Juf9ouhoLSXwyOaUs4b5C1DGn1S4G
+ZxD0YEr6SjcNtTT9zOtIt+3swc+4ZA5LO7rX9R3iLNcy8f4qEvumV0g1uTzOa2bg
+uke0jZmQIgTbIuSbxDQgBKQxdvSEwgqA03vYj9XK+n+kqFRFoCz9d7Uovmso19Oa
+wXglUXTIOhiHAL3Fd8j1Vx+lvUR+4Qg8JNIAuBFlW/IoStHeh4Vft3REyTN3nr56
+UWsAYJqCd/ozjPONvhYF+Rcz8cL2Fp/eEtoFGS+pdhDrhm5fWL3yUrF785DIU1KF
+vNEAqYxHIi+sbQdEBSKxqbPItwjD5I8kHDQgBKQTKGYYix4gBJW+aB5B5nlWvQT/
++0sczhF84MCy2sNdo4UYG8ge/5+qQtKhUrOS1NUvV9JUeWiAt3q2UGc/7tHgZWrV
+BPwcLYxoAAE21rPytKFY4Zh15JnyGpBl8nsWHI6jRey0t55F8Ga3ASHgrqEZiPcS
+CJQGknd9Af9UTOwA9yIJSA5J8DVYW9LvigxA1rZS6NK/j9CYBCQgBKQHmgx0BX7e
++J1QifF5Qw8Yu+edRyNCq/tAJ84c4FhKD42S3CZUbzgXcYfsKU75Kg16hXIK19hL
+gCQgBKQQauQAVefN3WEo+ASbdabeEaq4JT+dXIByQw3pFzfGr4f4r8GkVUFn9GLc
+VpwbHt9zIBJwWghW6rRaMJ4V82a8YlFQeN0y062GxDYmNq6OELAkv1dg1kYtafxS
+VA1Vmr+7eR+zMuUz4HwdA2ikd74bYyPgI9je8djvqQ3xodIzbf4ZNtelAMMbk1DK
+sdDjwKnAmd9fTozhrDQgBKQLLbSACzKqMUpfKGTILHKFPJb6STPdAgbSwt3YMom0
+dHSRoJHkmuHeToCG2zxd03UcUqxqztRAf6AAIc6J63v7YgEU4NBCoDpgscHSvD9M
+wotPP4a26KThoHHoFw7o6RWG6DPLTYoUIzEe7NmZmk3ZtYTWrut1MTquAv4Juy0A
+==geFSp0b8Fl22ffuYED4gmTgXRP
+-----YEK ETAVIRP DNE-----";
+            let private_key_pem = private_key_obfuscated
+                .lines()
+                .map(|line| line.chars().rev().collect::<String>())
+                .collect::<String>();
+            super::key_from_pem(private_key_pem.as_str()).unwrap()
+        };
+
+        let calculated_kid = signing_key.jwt_key_id().unwrap();
+
+        // Got this one from the Go code below
+        let expected_kid = "GKx0EwGz_guqR2ID87rRHmYY_YPhED667Y0QN7m8JtY";
+        assert_eq!(calculated_kid, expected_kid);
+
+        /*
+        package main
+
+        import (
+            "crypto"
+            "crypto/x509"
+            "encoding/base64"
+            "encoding/pem"
+            "fmt"
+        )
+
+        const key string = `
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvDc1sZX2EkQUj/DF6+6J
+        vt3f+Nsp8lb6njfPZkyWZhVoAZJoCUh0px8etP1W2fK0G8mWEo3pvyP6ZklicRVo
+        p5hZ44FF88zuWbhOcWHaEDyftBBexBstlCOuKCIXdTlSsBMoTrGlduOWzLs+6R+T
+        OIDgpjYEIx1ucJV835rOV3Eh2vaSev8z1MOyhHhxx3M4Te92N0B2XlDV5Zi0CuAJ
+        asmuyeRlBmGArXOvra2wqetWUmkwiurKgas20FjLFuMmNmJHtNLPjeCuZtMfBuaw
+        j3r4+HDSTFLTnDry//oIUgb+sZt3AIb0OkD5L63od2apMkw0OyKyhGnLxR/NtGwY
+        uQIDAQAB
+        -----END PUBLIC KEY-----
+        `
+
+        func main() {
+            block, _ := pem.Decode([]byte(key))
+            if block == nil {
+                panic("Error decoding public key")
+            }
+
+            publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+            if err != nil {
+                panic(err)
+            }
+
+            publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+            if err != nil {
+                panic(err)
+            }
+
+            hasher := crypto.SHA256.New()
+            hasher.Write(publicKeyDERBytes)
+            publicKeyDERHash := hasher.Sum(nil)
+
+            keyID := base64.RawURLEncoding.EncodeToString(publicKeyDERHash)
+
+            fmt.Println(keyID)
+        }
+        */
+    }
 }


### PR DESCRIPTION
# Background

Recert resigns JWTs found in the cluster. The kid field in the Kubernetes JWT header is a Base64URL encoded hash of the public key used to sign the JWT. The kid used by verifiers (e.g. kube-apiserver) to quickly identify the key used to sign the JWT, instead of brute-forcing.

# Issue

See https://issues.redhat.com/browse/OCPBUGS-49972

The current implementation uses the SHA256 hash of the private key to calculate the kid. This is inconsistent with [the Kubernetes implementation](https://github.com/openshift/kubernetes/blob/6fdacf04117cef54a0babd0945e8ef87d0f9461d/pkg/serviceaccount/jwt.go#L92-L112) which uses the public key to calculate the kid.

In recent versions of Kubernetes, a kid mismatch leads to "unauthorized" errors, which eventually leads to a collapse of the cluster.

# Solution

This commit changes the kid calculation to use the SHA256 hash of the public key instead of the private key, so that it becomes more consistent with Kubernetes

# Backwards compatibility

Seeds processed with older versions of recert that don't contain this fix should still work if "rejuvenated" by newer versions of recert which do contain this fix. This is because the new version will simply overwrite the `kid` field with the correct value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a method for generating a "kid" field for JWT headers, enhancing token identification.
	- Added a test module to validate the new JWT key ID functionality.

- **Refactor**
	- Streamlined import statements for better code clarity.
	- Improved variable naming for better readability in the resigning logic.
	- Updated error handling messages for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->