### PR TITLE
Print cert locations when re-signing fails

### DIFF
--- a/src/cluster_crypto/cert_key_pair.rs
+++ b/src/cluster_crypto/cert_key_pair.rs
@@ -135,7 +135,7 @@ impl CertKeyPair {
     /// # Errors
     ///
     /// This function will return an error if .
-    #[context["re-signing cert {} with subject {}", self.distributed_cert.borrow().locations ,self.distributed_cert.borrow().certificate.subject]]
+    #[context["re-signing cert at locations {} with subject {}", self.distributed_cert.borrow().locations, self.distributed_cert.borrow().certificate.subject]]
     pub(crate) fn re_sign_cert(
         &mut self,
         sign_with: Option<&SigningKey>,

--- a/src/cluster_crypto/cert_key_pair.rs
+++ b/src/cluster_crypto/cert_key_pair.rs
@@ -135,7 +135,7 @@ impl CertKeyPair {
     /// # Errors
     ///
     /// This function will return an error if .
-    #[context["re-signing cert with subject {}", self.distributed_cert.borrow().certificate.subject]]
+    #[context["re-signing cert {} with subject {}", self.distributed_cert.borrow().locations ,self.distributed_cert.borrow().certificate.subject]]
     pub(crate) fn re_sign_cert(
         &mut self,
         sign_with: Option<&SigningKey>,


### PR DESCRIPTION
This change adds the certificate locations to the `re_sign_cert(...)`'s error message to have more information about the certificate that caused the error.

For example, we currently have the following error message:

```text
Caused by:
    0: processing discovered objects
    1: regenerating crypto
    2: re-signing cert with subject CN=172.30.0.1
    3: could not find matching akid key identifier in chain
```

with this change we will have:

```text
Caused by:
    0: processing discovered objects
    1: regenerating crypto
    2: re-signing cert at locations [file:/kubelet/pods/<some-pod>/volumes/kubernetes.io~projected/etc-kubernetes-pki/etcd/server.crt:in PEM bundle at index 0] with subject CN=172.30.0.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced certificate error messages by including additional location details alongside subject information for improved troubleshooting context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->