### PR TITLE
OCPBUGS-52178: Identify external certs by hash rather than just name

### DIFF
--- a/src/recert.rs
+++ b/src/recert.rs
@@ -1,5 +1,9 @@
 use crate::{
-    cluster_crypto::{crypto_utils::ensure_openssl_version, scanning, ClusterCryptoObjects},
+    cluster_crypto::{
+        crypto_utils::ensure_openssl_version,
+        scanning::{self, ExternalCerts},
+        ClusterCryptoObjects,
+    },
     config::{ClusterCustomizations, CryptoCustomizations, EncryptionCustomizations, RecertConfig},
     encrypt::ResourceTransformers,
     k8s_etcd::InMemoryK8sEtcd,
@@ -12,7 +16,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use etcd_client::Client as EtcdClient;
-use std::{collections::HashSet, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use self::timing::{combine_timings, FinalizeTiming, RecertifyTiming, RunTime, RunTimes};
 
@@ -112,7 +116,7 @@ async fn recertify(
             .await
             .context("discovering external certs to ignore")?
     } else {
-        HashSet::new()
+        ExternalCerts::empty()
     };
 
     log::info!("Discovered {} external certificates to ignore", external_certs.len());


### PR DESCRIPTION
# Background

Recert looks at particular configmaps in the cluster to identify which certs are external to the cluster and thus should not be regenerated, so they are ignored from the rest of the recert process

# Issue

Sometimes people trust certs from other clusters that have the same name as certs inside the cluster. This causes recert to skip internal certs because it only compares the name.

# Solution

This commit changes the way we identify external certs to use the hash of the DER bytes of the certificate, instead of just the name. This method should be more robust and avoid this mistaken ignoring.

# Other changes

Will now use a new type called `ExternalCerts` to store the name and hash of the certificates instead of a HashMap. Since it gets passed around a lot its best to have it as a single type to make future changes easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced external certificate processing improves scanning reliability and error feedback, ensuring more robust certificate verification.
  
- **Refactor**
  - Streamlined certificate handling flows across the system by replacing generic implementations with a structured approach, resulting in better security and operational consistency.
  - Introduced a new structured type for external certificates, enabling more complex operations and improved data encapsulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->