### PR TITLE
Update renovate.json configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,7 @@
             "customType": "regex",
             "datasourceTemplate": "docker",
             "fileMatch": [
-                "\\.conf$",
-                "\\.yaml$",
-                "\\.yml$"
+                ".*konflux_build_args\\.conf$"
             ],
             "matchStrings": [
                 "(?<depName>[\\w\\-\\.\\/]+):?(?<currentValue>[\\w\\-\\.]+)?@(?<currentDigest>sha256:[a-f0-9]+)"


### PR DESCRIPTION
- The old configuration is causing every tekton digest update to occur individually which is extremely noisy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated configuration to restrict Docker datasource updates to a specific configuration file, reducing the scope of automated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->