### PR TITLE
Update `on-cel-expression` values for tekton pipelines to limit unnecessary builds

### DIFF
--- a/.tekton/recert-4-20-pull-request.yaml
+++ b/.tekton/recert-4-20-pull-request.yaml
@@ -8,7 +8,28 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && 
+      target_branch == "main" && 
+      (
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        'etcddump/***'.pathChanged() ||
+        'hack/***'.pathChanged() ||
+        'ouger/***'.pathChanged() ||
+        'src/***'.pathChanged() ||
+        'vendor/***'.pathChanged() ||
+        'build.rs'.pathChanged() ||
+        'Cargo.lock'.pathChanged() ||
+        'Cargo.toml'.pathChanged() ||
+        'ownership.sh'.pathChanged() ||
+        'reproto'.pathChanged() ||
+        'run_seed'.pathChanged() ||
+        'vendor.sh'.pathChanged() ||
+        '.tekton/recert-4-20-pull-request.yaml'.pathChanged() ||
+        '.konflux/Dockerfile'.pathChanged() || 
+        '.konflux/lock-build/***'.pathChanged() ||
+        '.konflux/lock-runtime/***'.pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: lifecycle-agent-4-20

--- a/.tekton/recert-4-20-push.yaml
+++ b/.tekton/recert-4-20-push.yaml
@@ -8,7 +8,28 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && files.all != ["konflux_clusterserviceversion_overlay.data"]
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" && 
+      target_branch == "main" && 
+      (
+        '.tekton/build-pipeline.yaml'.pathChanged() ||
+        'etcddump/***'.pathChanged() ||
+        'hack/***'.pathChanged() ||
+        'ouger/***'.pathChanged() ||
+        'src/***'.pathChanged() ||
+        'vendor/***'.pathChanged() ||
+        'build.rs'.pathChanged() ||
+        'Cargo.lock'.pathChanged() ||
+        'Cargo.toml'.pathChanged() ||
+        'ownership.sh'.pathChanged() ||
+        'reproto'.pathChanged() ||
+        'run_seed'.pathChanged() ||
+        'vendor.sh'.pathChanged() ||
+        '.tekton/recert-4-20-push.yaml'.pathChanged() ||
+        '.konflux/Dockerfile'.pathChanged() || 
+        '.konflux/lock-build/***'.pathChanged() ||
+        '.konflux/lock-runtime/***'.pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: lifecycle-agent-4-20


### PR DESCRIPTION
- The Konflux build should only run if something that would affect the build was modified
