### PR TITLE
Disable minor updates from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,10 @@
                 "digest"
             ],
             "platformAutomerge": true
+        },
+        {
+            "matchUpdateTypes": ["minor"],
+            "enabled": false
         }
     ],
     "prConcurrentLimit": 0,


### PR DESCRIPTION
- We generally keep this in sync with the current OCP release, so having to constantly decline PRs is getting annoying