### PR TITLE
Update owners configuration

### DIFF
--- a/.konflux/OWNERS
+++ b/.konflux/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-  - konflux-approvers

--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,2 +1,0 @@
-approvers:
-  - konflux-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,36 @@
+---
 # See the OWNERS docs at https://go.k8s.io/owners
 
 component: "Telco Edge"
-subcomponent: "Recert"
-
 filters:
   ".*":
-    reviewers:
-      - recert-reviewers
     approvers:
       - recert-approvers
-  ^Dockerfile:
     reviewers:
-    - rauhersu
+      - recert-reviewers
+  ".konflux/*":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  ".tekton/*":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  ^Dockerfile:
     labels:
       - downstream-change-needed
+    reviewers:
+      - rauhersu
+  "renovate.json":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+  "telco5g-konflux/":
+    approvers:
+      - konflux-approvers
+    reviewers:
+      - konflux-reviewers
+subcomponent: "Recert"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,13 +1,22 @@
+---
 # See the OWNERS docs at https://go.k8s.io/owners
+
 aliases:
-  recert-reviewers:
-    - omertuc
-    - mresvanis
-    - tsorya
+  konflux-approvers:
+    - abraham2512
+    - fontivan
+    - rauhersu
+    - sabbir-47
+    - shajmakh
+    - yanirq
+  konflux-reviewers:
+    - fontivan
+    - rauhersu
   recert-approvers:
     - omertuc
     - mresvanis
     - tsorya
-  konflux-approvers:
-    - fontivan
-    - rauhersu
+  recert-reviewers:
+    - omertuc
+    - mresvanis
+    - tsorya


### PR DESCRIPTION
- Apply yamllint formatting to OWNERS and OWNERS_ALIASES
- Add additional Konflux approvers
- Move owners configuration for .tekton and .konflux into top level folder
- Add additional owners configuration for the telco5g-konflux submodule and renovate.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated repository ownership configuration: expanded approver group membership, added a dedicated reviewer group, and consolidated aliases.
  - Reorganized path-specific ownership rules to reflect the new groups and moved a subcomponent block for clarity.
  - Renamed a previous approver group to a reviewer group and removed redundant approver blocks.
  - Contributor impact: approval responsibilities and default reviewers for specific areas have changed, which may affect who can approve and who is requested for reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->