### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,9 +86,6 @@
         "managerFilePatterns": [
             "/\\.yaml$/",
             "/\\.yml$/"
-        ],
-        "schedule": [
-            "at any time"
         ]
     }
 }


### PR DESCRIPTION
- Remove `at any time` schedule from tekton updates
- This is causing multiple PRs per week and is quite noisey
- By removing it we return to the Mintmaker default which is once a week, which should be plenty