### PR TITLE
CNF-19739: Add missing EUS repos to rpm lock configuration

### DIFF
--- a/.konflux/lock-build/rpms.in.yaml
+++ b/.konflux/lock-build/rpms.in.yaml
@@ -20,6 +20,20 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-appstream-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - AppStream EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/appstream/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-rpms
       name: Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/baseos/os
@@ -34,9 +48,37 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-baseos-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - BaseOS EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/baseos/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: codeready-builder-for-rhel-9-$basearch-rpms
       name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/codeready-builder/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
+    - repoid: codeready-builder-for-rhel-9-$basearch-eus-rpms
+      name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/codeready-builder/os
       enabled: "1"
       gpgcheck: "1"
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/.konflux/lock-build/rpms.lock.yaml
+++ b/.konflux/lock-build/rpms.lock.yaml
@@ -11,41 +11,6 @@ arches:
     name: cargo
     evr: 1.75.0-1.el9
     sourcerpm: rust-1.75.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/c/cpp-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 10801753
-    checksum: sha256:8045909729e63fcaf1a7f70b2f21657fdefa6e886828cfa6b72bee03dcc7eefd
-    name: cpp
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/g/gcc-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 31279520
-    checksum: sha256:5345b9f67ff0e6d116d22d6ac0e3c00269df72a0ec14ac08ac571523349b878c
-    name: gcc
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 562909
-    checksum: sha256:659ea1f0a46b8ac68babb9db5494e549ba366e18a2ed02e9b9da170c0bdefa9d
-    name: glibc-devel
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-427.42.1.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 6541529
-    checksum: sha256:fda104e35b0ca0d60950e2d97af914b29557e0d3d77e0e5d443a1f5af6312736
-    name: kernel-headers
-    evr: 5.14.0-427.42.1.el9_4
-    sourcerpm: kernel-5.14.0-427.42.1.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libasan-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 421373
-    checksum: sha256:a085db9b8ff3e9fc6749f1f7298737f8485d404b18079f958901f6f4f139e47a
-    name: libasan
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 67120
@@ -53,13 +18,6 @@ arches:
     name: libmpc
     evr: 1.2.1-4.el9
     sourcerpm: libmpc-1.2.1-4.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libubsan-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 191207
-    checksum: sha256:bd6b3bcea8dd5e9d7212d52552fce2a6687a978a38aa9e4a92448aa585398b33
-    name: libubsan
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 33051
@@ -95,6 +53,13 @@ arches:
     name: rust-std-static
     evr: 1.75.0-1.el9
     sourcerpm: rust-1.75.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/appstream/os/Packages/r/rust-toolset-1.75.0-1.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-appstream-rpms
+    size: 13082
+    checksum: sha256:d1b99a3fe42114436dd35ed0010cea12ad5205685dbdb83bd30837715f2b202f
+    name: rust-toolset
+    evr: 1.75.0-1.el9
+    sourcerpm: rust-1.75.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/b/binutils-2.35.2-43.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 5024988
@@ -116,41 +81,6 @@ arches:
     name: elfutils-debuginfod-client
     evr: 0.190-2.el9
     sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/glibc-2.34-100.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1807264
-    checksum: sha256:5cfa27d2cf523ca88c1c3a9c421e65593edfe8818bc890cafa4cc4393db61d3f
-    name: glibc
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/glibc-common-2.34-100.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 303509
-    checksum: sha256:e66a3fe284e02ad5011c072ba0123c50fe05f13a35b41b53f31a4ea9718f8910
-    name: glibc-common
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/glibc-langpack-en-2.34-100.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 674935
-    checksum: sha256:58abb4729f14f90c970eaee051d5e1a6a2a8faea40b8ba781e92b2dc01b42fd4
-    name: glibc-langpack-en
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-100.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 21093
-    checksum: sha256:b76ac4acb689e60455358cc4b49cfdc4aa2df9c8b8f76f2727c7025a51bc915f
-    name: glibc-minimal-langpack
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libatomic-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 38225
-    checksum: sha256:9f858f9f01d74bb00b64934b4306cfe8a6383379816a9ab5b9103d1551bea52b
-    name: libatomic
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 107505
@@ -158,13 +88,6 @@ arches:
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libgomp-11.4.1-3.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 275251
-    checksum: sha256:87ff930132434e16650b4b40f0bb86e9edc5ce399608113afc0afbf2aa084a5e
-    name: libgomp
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 38310
@@ -186,6 +109,13 @@ arches:
     name: pkgconf
     evr: 1.7.3-10.el9
     sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 12398
@@ -200,20 +130,55 @@ arches:
     name: protobuf-compiler
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/r/rust-toolset-1.75.0-1.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 13082
-    checksum: sha256:d1b99a3fe42114436dd35ed0010cea12ad5205685dbdb83bd30837715f2b202f
-    name: rust-toolset
-    evr: 1.75.0-1.el9
-    sourcerpm: rust-1.75.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 16054
-    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
-    name: pkgconf-m4
-    evr: 1.7.3-10.el9
-    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/c/cpp-11.4.1-4.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 10793089
+    checksum: sha256:763b38ec9b982b3253bac4a81dcb7be622e5f77a7d2ee5f3e6ba145ad7829ceb
+    name: cpp
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/gcc-11.4.1-4.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 31258590
+    checksum: sha256:e9f3dcc635528fec74d36fd439c5876bccdce948d58f83345b1973e7379ef507
+    name: gcc
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.12.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 551742
+    checksum: sha256:f61e0fbb016a901d59633be70124c253d5c10ae47cafd5b03aa198164e3ef121
+    name: glibc-devel
+    evr: 2.34-100.el9_4.12
+    sourcerpm: glibc-2.34-100.el9_4.12.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/k/kernel-headers-5.14.0-427.92.1.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 3321677
+    checksum: sha256:8e8347a0aa359523a3cd9b4c9a54dbdd2da4931bf0ddb12675ae837a7db3e5ad
+    name: kernel-headers
+    evr: 5.14.0-427.92.1.el9_4
+    sourcerpm: kernel-5.14.0-427.92.1.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/l/libasan-11.4.1-4.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 410341
+    checksum: sha256:907086eb8540a4ae846cd6a81661026e77e988a54c8d6de9c8a499557537b589
+    name: libasan
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/appstream/os/Packages/l/libubsan-11.4.1-4.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 180497
+    checksum: sha256:e651887af299729f3bdb651827f1539470a45e4fd6c554b0f48fd3708ce3eee5
+    name: libubsan
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/l/libatomic-11.4.1-4.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 27560
+    checksum: sha256:871dc99bf2f04acfcf46284f503b93f72bd36ccfabb4da4610eb4b00fde56f15
+    name: libatomic
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
@@ -225,41 +190,6 @@ arches:
     name: cargo
     evr: 1.75.0-1.el9
     sourcerpm: rust-1.75.0-1.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/c/cpp-11.4.1-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 11153534
-    checksum: sha256:45907c9130a09f20f2e7bdb09f7371a1b6221c161a492dfab0a744fbe5e66e7e
-    name: cpp
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/g/gcc-11.4.1-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 33805852
-    checksum: sha256:18668f95c29b72e90ff42811a378c8c2ee8db71aff07de09a156aa7388720cb8
-    name: gcc
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 36205
-    checksum: sha256:c7c88469c845e5550037d17d544c2fdcde683e6410e6aad77b5cdd09580d15ca
-    name: glibc-devel
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-headers-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 553893
-    checksum: sha256:2dc0c045df41e6d5f34c846a8c8ffd77b1618bdd05b920f85bb27742b208bcff
-    name: glibc-headers
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-427.42.1.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 6578513
-    checksum: sha256:a7767c560b0ca3864c47284316c73f58a7ff01b0be46ec4330a635b19ad80f5f
-    name: kernel-headers
-    evr: 5.14.0-427.42.1.el9_4
-    sourcerpm: kernel-5.14.0-427.42.1.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 66075
@@ -330,34 +260,6 @@ arches:
     name: elfutils-debuginfod-client
     evr: 0.190-2.el9
     sourcerpm: elfutils-0.190-2.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/glibc-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 2066882
-    checksum: sha256:f2ab157525ff3ab2d4e6fa0d77fa58e0d6174a167a6c378d9302f146926f6bdb
-    name: glibc
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/glibc-common-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 314113
-    checksum: sha256:85f9311225af5fdd235f23b63f243058aeee9b65b14c55a2d9bbdd1409de8970
-    name: glibc-common
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 674961
-    checksum: sha256:404ea4f5108366a13109b46230ced6e7fe96fdf6aa90ea2bcf9b63f25ba1a702
-    name: glibc-langpack-en
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-100.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 21129
-    checksum: sha256:1e85eceb7b60d23c1f9f93373e3a03d1938fe8362ff5dca9889226984149570c
-    name: glibc-minimal-langpack
-    evr: 2.34-100.el9_4.4
-    sourcerpm: glibc-2.34-100.el9_4.4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 109330
@@ -365,13 +267,6 @@ arches:
     name: libedit
     evr: 3.1-38.20210216cvs.el9
     sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libgomp-11.4.1-3.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 276984
-    checksum: sha256:6aeb5c48a9c01c9f383cbaf99d2b550faa64fcbe298c546db9b98651088bcf55
-    name: libgomp
-    evr: 11.4.1-3.el9
-    sourcerpm: gcc-11.4.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38387
@@ -414,5 +309,40 @@ arches:
     name: protobuf-compiler
     evr: 3.14.0-13.el9
     sourcerpm: protobuf-3.14.0-13.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/c/cpp-11.4.1-4.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 11143019
+    checksum: sha256:f4535a6a48a126be6134fdce68c1f41cece00f67208c2314b9ed24052457e056
+    name: cpp
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/gcc-11.4.1-4.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 33794491
+    checksum: sha256:eb4f59b42086f57aa2c5d98e70d14bfdc468e374fb9e3cfeb8047522337c2ec4
+    name: gcc
+    evr: 11.4.1-4.el9_4
+    sourcerpm: gcc-11.4.1-4.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-devel-2.34-100.el9_4.12.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 25115
+    checksum: sha256:bdf5acc5d7429d0f21d4f1119835248629934a42212890cd45d80af8e9120a26
+    name: glibc-devel
+    evr: 2.34-100.el9_4.12
+    sourcerpm: glibc-2.34-100.el9_4.12.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/g/glibc-headers-2.34-100.el9_4.12.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 542973
+    checksum: sha256:4ea06ba947c5cc08fab411b16855f2bce1a346f181fb7b03eb74b8e185d7b6de
+    name: glibc-headers
+    evr: 2.34-100.el9_4.12
+    sourcerpm: glibc-2.34-100.el9_4.12.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-427.92.1.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 3358669
+    checksum: sha256:1506601358b8abeb10f0f16ebcf8aa6d92c7b00a091ba3f70092d6e9ae8baa9b
+    name: kernel-headers
+    evr: 5.14.0-427.92.1.el9_4
+    sourcerpm: kernel-5.14.0-427.92.1.el9_4.src.rpm
   source: []
   module_metadata: []

--- a/.konflux/lock-runtime/rpms.in.yaml
+++ b/.konflux/lock-runtime/rpms.in.yaml
@@ -20,6 +20,20 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-appstream-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - AppStream EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/appstream/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: rhel-9-for-$basearch-baseos-rpms
       name: Red Hat Enterprise Linux 9 for $basearch - BaseOS (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/baseos/os
@@ -34,9 +48,37 @@ contentOrigin:
       metadata_expire: "86400"
       enabled_metadata: "1"
       varsFromContainerfile: Dockerfile
+    - repoid: rhel-9-for-$basearch-baseos-eus-rpms
+      name: Red Hat Enterprise Linux 9 for $basearch - BaseOS EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/baseos/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
     - repoid: codeready-builder-for-rhel-9-$basearch-rpms
       name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch (RPMs)
       baseurl: https://cdn.redhat.com/content/dist/rhel9/{version}/$basearch/codeready-builder/os
+      enabled: "1"
+      gpgcheck: "1"
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+      sslverify: "1"
+      sslcacert: /etc/rhsm/ca/redhat-uep.pem
+      sslclientkey: /etc/pki/entitlement/placeholder-key.pem
+      sslclientcert: /etc/pki/entitlement/placeholder.pem
+      sslverifystatus: "1"
+      metadata_expire: "86400"
+      enabled_metadata: "1"
+      varsFromContainerfile: Dockerfile
+    - repoid: codeready-builder-for-rhel-9-$basearch-eus-rpms
+      name: Red Hat CodeReady Linux Builder for RHEL 9 $basearch EUS (RPMs)
+      baseurl: https://cdn.redhat.com/content/eus/rhel9/{version}/$basearch/codeready-builder/os
       enabled: "1"
       gpgcheck: "1"
       gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release

--- a/.konflux/lock-runtime/rpms.lock.yaml
+++ b/.konflux/lock-runtime/rpms.lock.yaml
@@ -81,41 +81,6 @@ arches:
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 466503
-    checksum: sha256:4d3e43a76fc2242e8a0e0beb9e2113cafb0bbcb0e5c488330d2a989ba723cf16
-    name: openssh
-    evr: 8.7p1-38.el9_4.4
-    sourcerpm: openssh-8.7p1-38.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 705715
-    checksum: sha256:e4dde18b7bf746fa8099dc219523384838fc2ab27521bd154294e837a42adc54
-    name: openssh-clients
-    evr: 8.7p1-38.el9_4.4
-    sourcerpm: openssh-8.7p1-38.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/o/openssl-3.0.7-28.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1246716
-    checksum: sha256:23aaee350db63934f7afc9fca10c65c1df6f95561659bbf6f3c045219b4252c9
-    name: openssl
-    evr: 1:3.0.7-28.el9_4
-    sourcerpm: openssl-3.0.7-28.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/o/openssl-libs-3.0.7-28.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 1878584
-    checksum: sha256:2844734aa1cef6d41802d074d4f0491dce3e6a28b9a928dc5e5011801f32722a
-    name: openssl-libs
-    evr: 1:3.0.7-28.el9_4
-    sourcerpm: openssl-3.0.7-28.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/p/pam-1.5.1-19.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 646757
-    checksum: sha256:37683e8ae32dc4f5bfff343d91d83f595905fa4ec990f25a5d70da893a3d9033
-    name: pam
-    evr: 1.5.1-19.el9
-    sourcerpm: pam-1.5.1-19.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/aarch64/baseos/os/Packages/u/util-linux-2.37.4-18.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 2394535
@@ -130,6 +95,34 @@ arches:
     name: util-linux-core
     evr: 2.37.4-18.el9
     sourcerpm: util-linux-2.37.4-18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 463505
+    checksum: sha256:2d90c96a3b297af8a0a3c89b0836c0b12317d6225ad20bfc8f892fcea4ef0ae5
+    name: openssh
+    evr: 8.7p1-38.el9_4.5
+    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.5.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 705635
+    checksum: sha256:88c3b641ec06dc581063dbd5934342db8a4996287dfcb51a8ef5f5665df8e23d
+    name: openssh-clients
+    evr: 8.7p1-38.el9_4.5
+    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/o/openssl-3.0.7-29.el9_4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 1244228
+    checksum: sha256:aa2685dd4c7134d38eb069f8bc2e1ec130d3422dd050d26c00949c5a917cc3c4
+    name: openssl
+    evr: 1:3.0.7-29.el9_4
+    sourcerpm: openssl-3.0.7-29.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/aarch64/baseos/os/Packages/p/pam-1.5.1-24.el9_4.1.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 643278
+    checksum: sha256:a72cd2a43b9477c4fa1c097e513f38b1ff7694627acd1063d80eea33427bc2b3
+    name: pam
+    evr: 1.5.1-24.el9_4.1
+    sourcerpm: pam-1.5.1-24.el9_4.1.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
@@ -211,41 +204,6 @@ arches:
     name: libutempter
     evr: 1.2.1-6.el9
     sourcerpm: libutempter-1.2.1-6.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 477128
-    checksum: sha256:4dfc84f29b23f1d227c99eb32adbb425cee0aea039101dfcb7184787d85e1f13
-    name: openssh
-    evr: 8.7p1-38.el9_4.4
-    sourcerpm: openssh-8.7p1-38.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 739455
-    checksum: sha256:d5fee8ce71d338cb20386c647d1f20b7a4310db2280e470fc2744de11731b508
-    name: openssh-clients
-    evr: 8.7p1-38.el9_4.4
-    sourcerpm: openssh-8.7p1-38.el9_4.4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/o/openssl-3.0.7-28.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1268306
-    checksum: sha256:255fb57a1b308c1f2df2027c63953955717498a76056f4d4e1279f02001e9aa8
-    name: openssl
-    evr: 1:3.0.7-28.el9_4
-    sourcerpm: openssl-3.0.7-28.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/o/openssl-libs-3.0.7-28.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 1986963
-    checksum: sha256:9f5939d641e236dae1c75ba05395f3fa644dddc3ba74a58a729e3c2384c86c1b
-    name: openssl-libs
-    evr: 1:3.0.7-28.el9_4
-    sourcerpm: openssl-3.0.7-28.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/p/pam-1.5.1-19.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 646595
-    checksum: sha256:19366591c6a2b50d354bc27cce98e707d6c23fa92af4addb93ed7237f2818711
-    name: pam
-    evr: 1.5.1-19.el9
-    sourcerpm: pam-1.5.1-19.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9.4/x86_64/baseos/os/Packages/u/util-linux-2.37.4-18.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 2396787
@@ -260,5 +218,33 @@ arches:
     name: util-linux-core
     evr: 2.37.4-18.el9
     sourcerpm: util-linux-2.37.4-18.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-8.7p1-38.el9_4.5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 474293
+    checksum: sha256:44c59d9397cfa395e146155a01fdb0fc5b9e87d597a9a9b9fc5fe345a5b46b67
+    name: openssh
+    evr: 8.7p1-38.el9_4.5
+    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-38.el9_4.5.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 736808
+    checksum: sha256:3897e45c11ee0c6d9a5ca3d5f02bfa45187aae4628737244d1da73446b29dc14
+    name: openssh-clients
+    evr: 8.7p1-38.el9_4.5
+    sourcerpm: openssh-8.7p1-38.el9_4.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/o/openssl-3.0.7-29.el9_4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1265961
+    checksum: sha256:aa92fbd2ebf2087b784857f1daa6f1fe665b0a50bf73d777943cae487fcf6072
+    name: openssl
+    evr: 1:3.0.7-29.el9_4
+    sourcerpm: openssl-3.0.7-29.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/Packages/p/pam-1.5.1-24.el9_4.1.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 645046
+    checksum: sha256:850327c6e6415e4f0ca55c353227135672fe9aced101815ddad08d66852ba693
+    name: pam
+    evr: 1.5.1-24.el9_4.1
+    sourcerpm: pam-1.5.1-24.el9_4.1.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
[CNF-19739](https://issues.redhat.com//browse/CNF-19739): Add missing EUS repos to rpm lock configuration
    - This is required to receive updated packages for each 9.x release
    - Re-run lock generation to update all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added EUS (extended‑support) RPM repository variants and enabled numerous packages to use EUS channels for both architectures.
  - Updated lock data to reflect new EUS sources and package version/metadata adjustments where channel changes applied.
  - Added pkgconf-m4 to BaseOS for aarch64 and x86_64.
  - Rust toolset moved to EUS AppStream for aarch64; x86_64 entries also aligned to EUS equivalents.
  - Moved openssh/openssl/pam packages to EUS channels across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->