### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for recert

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -105,6 +105,10 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - default: []
+      description: Additional labels to apply to the built container image
+      name: additional-labels
+      type: array
   results:
     - description: ""
       name: IMAGE_URL
@@ -250,12 +254,13 @@ spec:
         - name: LABELS
           value:
             - $(tasks.generate-labels.results.labels[*])
+            - $(params.additional-labels[*])
             - com.redhat.component=recert
             - description=recert
             - distribution-scope=public
             - io.k8s.description=recert
-            - name=openshift4/recert-rhel9
             - release=4.20
+            - cpe="cpe:/a:redhat:openshift:4.20::el9"
             - url=https://github.com/rh-ecosystem-edge/recert
             - vendor=Red Hat, Inc.
             - io.k8s.display-name=recert

--- a/.tekton/recert-4-20-pull-request.yaml
+++ b/.tekton/recert-4-20-pull-request.yaml
@@ -70,6 +70,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/recert-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/recert-4-20-push.yaml
+++ b/.tekton/recert-4-20-push.yaml
@@ -68,6 +68,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/recert-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Based on original changes from @rbean in our other operator repos

Assisted-by: Gemini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add support for custom container image labels via a new pipeline parameter.
  - Include a standardized CPE label for OpenShift 4.20 on EL9 in built images.

- Chores
  - Update build and run configurations to pass additional labels to image builds.
  - Replace a previously hard-coded image label with the new configurable approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->