### PR TITLE
[release-4.14] chore(KONFLUX-6210): fix and set name and cpe label for recert

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -105,6 +105,10 @@ spec:
       default: docker
       type: string
       description: The format for the resulting image's mediaType. Valid values are oci or docker.
+    - default: []
+      description: Additional labels to apply to the built container image
+      name: additional-labels
+      type: array
   results:
     - description: ''
       name: IMAGE_URL
@@ -250,12 +254,13 @@ spec:
         - name: LABELS
           value:
             - $(tasks.generate-labels.results.labels[*])
+            - $(params.additional-labels[*])
             - com.redhat.component=recert
             - description=recert
             - distribution-scope=public
             - io.k8s.description=recert
-            - name=openshift4/recert-rhel9
-            - release=4.15
+            - release=4.14
+            - cpe="cpe:/a:redhat:openshift:4.14::el9"
             - url=https://github.com/rh-ecosystem-edge/recert
             - vendor=Red Hat, Inc.
             - io.k8s.display-name=recert

--- a/.tekton/recert-4-14-pull-request.yaml
+++ b/.tekton/recert-4-14-pull-request.yaml
@@ -69,6 +69,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: []
+    - name: additional-labels
+      value:
+        - name=openshift4/recert-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/recert-4-14-push.yaml
+++ b/.tekton/recert-4-14-push.yaml
@@ -67,6 +67,9 @@ spec:
       value: "true"
     - name: additional-tags
       value: ["latest"]
+    - name: additional-labels
+      value:
+        - name=openshift4/recert-rhel9
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Based on original changes from @rbean in our other operator repos

Assisted-by: Gemini